### PR TITLE
Add e2e tests of user routes

### DIFF
--- a/behave/.gitignore
+++ b/behave/.gitignore
@@ -1,0 +1,2 @@
+behave_env.sh
+geckodriver.log

--- a/behave/Dockerfile
+++ b/behave/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:18.04
+
+WORKDIR /usr/src/app
+RUN apt-get update
+RUN apt-get install -y apt-utils zip unzip
+RUN apt-get install -y python3.7 python3-distutils python3-pip
+RUN apt-get install -y build-essential libssl-dev libffi-dev python3-dev
+RUN apt-get install -y curl tar imagemagick python-gtk2
+RUN apt-get install -y libglib2.0-0 libnss3 libgconf-2-4 libfontconfig1
+
+# install chromedriver and headless-chrome
+RUN mkdir ./bin
+COPY bin/* ./bin/
+RUN bash bin/install_chrome.sh
+
+ENV PATH=.:/opt:$PATH
+
+# Install python deps
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY . .

--- a/behave/Makefile
+++ b/behave/Makefile
@@ -1,0 +1,15 @@
+.SHELL := /bin/sh
+.DEFAULT_GOAL := zip
+.PHONY = clean
+
+rebuild:
+	docker-compose build
+
+run: rebuild
+	docker-compose run chrome-driver bash -c ". /usr/src/app/behave_env.sh && behave"
+
+test:
+	behave
+
+shell: rebuild
+	docker-compose run chrome-driver bash

--- a/behave/README.md
+++ b/behave/README.md
@@ -1,0 +1,17 @@
+# End to end testing 
+
+## Run locally 
+
+`make run`
+
+## Building the docker container 
+
+
+```
+# NOTE: Replace version with the bumped version number
+docker build --no-cache -t gdscyber/concourse-chrome-driver -t gdscyber/concourse-chrome-driver:1.0 .
+
+# Then to push to DockerHub:
+docker push gdscyber/concourse-chrome-driver:1.0
+docker push gdscyber/concourse-chrome-driver:latest 
+```

--- a/behave/README.md
+++ b/behave/README.md
@@ -1,6 +1,21 @@
 # End to end testing 
 
-## Run locally 
+## Run locally
+
+You need a `behave_env.sh` file which should look like 
+the following: 
+
+```behave_env.sh
+#! /bin/bash
+export E2E_STAGING_ROOT_URL=https://corona-backend-consumer-stag.cloudapps.digital/
+export E2E_STAGING_USERNAME=[e2e_username_value]
+export E2E_STAGING_PASSWORD=[e2e_password_value]
+```  
+
+The credentials need to be for a cognito account which is 
+able to login without an MFA SMS. 
+
+Then you can run
 
 `make run`
 

--- a/behave/behave.ini
+++ b/behave/behave.ini
@@ -1,0 +1,3 @@
+[behave]
+stderr_capture=False
+stdout_capture=False

--- a/behave/bin/install_chrome.sh
+++ b/behave/bin/install_chrome.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+CHROME_DRIVER_VERSION=70.0.3538.16    # 2.37
+HEADLESS_CHROME_VERSION=v1.0.0-55     # v1.0.0-41
+
+cd /opt
+curl -SL https://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip > chromedriver.zip
+unzip chromedriver.zip
+rm chromedriver.zip
+# download chrome binary
+curl -SL https://github.com/adieuadieu/serverless-chrome/releases/download/${HEADLESS_CHROME_VERSION}/stable-headless-chromium-amazonlinux-2017-03.zip > headless-chromium.zip
+unzip headless-chromium.zip
+rm headless-chromium.zip
+ln -fs /opt/headless-chromium /opt/chrome

--- a/behave/docker-compose.yaml
+++ b/behave/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  chrome-driver:
+    build: .
+    volumes:
+      - .:/usr/src/app
+    command: bash
+    environment:
+      - ENVIRONMENT=test

--- a/behave/features/1.user_home.feature
+++ b/behave/features/1.user_home.feature
@@ -1,0 +1,5 @@
+# COVID19 - Homepage Feature
+Feature: COVID19 Data Transfer - Homepage loads
+    Scenario: can load homepage
+        When you navigate to user home
+        Then the content of element with selector ".govuk-heading-xl" contains "COVID-19 Data Transfer"

--- a/behave/features/2.user_login.feature
+++ b/behave/features/2.user_login.feature
@@ -1,0 +1,14 @@
+# COVID19 - User login feature
+Feature: COVID19 Data Transfer - User login
+    Scenario: user can login
+        Given the credentials
+        When you navigate to user home
+        When you click on ".govuk-button"
+        Then wait "5" seconds
+        When oauth username is set
+        When oauth password is set
+        # When oauth sign in button is clicked
+        When oauth form is submitted
+        Then wait "5" seconds
+        Then the content of element with selector ".govuk-heading-xl" contains "COVID-19 Data Transfer"
+        Then the content of element with selector "#main-content :nth-child(2)" contains username

--- a/behave/features/3.user_files.feature
+++ b/behave/features/3.user_files.feature
@@ -1,0 +1,10 @@
+# COVID19 - User access files feature
+Feature: COVID19 Data Transfer - User files
+    Scenario: user can login
+        Given the credentials
+        When you navigate to user home
+        When you click on "#main-content .govuk-button--start"
+        Then wait "5" seconds
+        Then the content of element with selector ".govuk-heading-xl" contains "COVID-19 Data Transfer"
+        Then the content of element with selector "#main-content :nth-child(2)" contains username
+        Then the content of element with selector "#main-content a[href^='/download']" equals "web-app-prod-data/other/gds/not-real-data-other-gds.csv"

--- a/behave/features/4.user_logout.feature
+++ b/behave/features/4.user_logout.feature
@@ -1,0 +1,9 @@
+# COVID19 - User access to files
+Feature: COVID19 Data Transfer - User files
+    Scenario: user can login
+        Given the credentials
+        When you navigate to user home
+        When you click on "#main-content .govuk-button--secondary"
+        Then wait "5" seconds
+        Then the content of element with selector ".govuk-heading-xl" contains "COVID-19 Data Transfer"
+        Then the content of element with selector "#main-content :nth-child(2)" equals "This is a new service for pre-registered users to access."

--- a/behave/features/5.logged_out_denies_files.feature
+++ b/behave/features/5.logged_out_denies_files.feature
@@ -1,0 +1,5 @@
+# COVID19 - Deny logged out access to files
+Feature: COVID19 Data Transfer - Logged out files route is denied
+    Scenario: cannot access files route when logged out
+        When you navigate to "files"
+        Then you get redirected to user home

--- a/behave/features/6.logged_out_denies_download.feature
+++ b/behave/features/6.logged_out_denies_download.feature
@@ -1,0 +1,5 @@
+# COVID19 - Deny logged out access to download
+Feature: COVID19 Data Transfer - Logged out download route is denied
+    Scenario: cannot access download route when logged out
+        When you navigate to "download"
+        Then you get redirected to user home

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -1,0 +1,25 @@
+import requests
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+
+def before_all(context):
+    context.api_session = requests.Session()
+    # options = webdriver.FirefoxOptions()
+    # options.headless = os.environ["E2E_HEADLESS"] == "true"
+    # context.browser = webdriver.Firefox(options=options)
+    # context.browser.set_window_size(1080,800)
+
+    options = Options()
+    options.binary = "bin/headless-chromium"
+    options.add_argument("-headless")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--single-process")
+    options.add_argument("--disable-dev-shm-usage")
+
+    context.browser = webdriver.Chrome("/opt/chromedriver", chrome_options=options)
+    context.browser.set_window_size(1080, 800)
+
+
+def after_all(context):
+    context.browser.quit()

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -1,0 +1,28 @@
+import time
+
+from behave import then, when
+
+
+@when('visit url "{url}"')
+def visit_url_step(context, url):
+    context.browser.get(url)
+
+
+@when('you click on "{selector}"')
+def click_on_step(context, selector):
+    elem = context.browser.find_element_by_css_selector(selector)
+    elem.click()
+    time.sleep(5)
+
+
+@when('field with name "{selector}" is given "{value}"')
+def set_field_value_step(context, selector, value):
+    elem = context.browser.find_element_by_name(selector)
+    elem.send_keys(value)
+    elem.submit()
+    time.sleep(5)
+
+
+@then('title becomes "{title}"')
+def check_browser_title_step(context, title):
+    assert context.browser.title == title

--- a/behave/features/steps/user_routes.py
+++ b/behave/features/steps/user_routes.py
@@ -1,0 +1,94 @@
+import os
+import time
+
+from behave import given, then, when
+
+
+@given("the credentials")
+def credentials_step(context):
+    context.browser.header_overrides = {
+        "e2e_username": os.environ["E2E_STAGING_USERNAME"],
+        "e2e_password": os.environ["E2E_STAGING_PASSWORD"],
+    }
+
+
+@when("oauth username is set")
+def login_username_step(context):
+    elem = context.browser.find_element_by_css_selector(
+        ".visible-md .modal-body #signInFormUsername"
+    )
+    elem.click()
+    elem.send_keys(context.browser.header_overrides["e2e_username"])
+
+
+@when("oauth password is set")
+def login_password_step(context):
+    elem = context.browser.find_element_by_css_selector(
+        ".visible-md .modal-body #signInFormPassword"
+    )
+    elem.click()
+    elem.send_keys(context.browser.header_overrides["e2e_password"])
+
+
+@when("oauth form is submitted")
+def login_submit_step(context):
+    elem = context.browser.find_element_by_css_selector(
+        ".visible-md .modal-body #signInFormPassword"
+    )
+    elem.submit()
+
+
+@when("oauth sign in button is clicked")
+def login_submit_button_click_step(context):
+    elem = context.browser.find_element_by_name(
+        ".visible-md .modal-body .btn.btn-primary.submitButton-customizable"
+    )
+    elem.submit()
+
+
+@when("you navigate to user home")
+def user_home_step(context):
+    url = os.environ["E2E_STAGING_ROOT_URL"]
+    context.browser.get(url)
+
+
+@when('you navigate to "{path}"')
+def user_path_step(context, path):
+    url = os.environ["E2E_STAGING_ROOT_URL"]
+    context.browser.get(f"{url}{path}")
+
+
+@then("you get redirected to user home")
+def user_redirect_step(context):
+    url = os.environ["E2E_STAGING_ROOT_URL"]
+    assert context.browser.current_url == url
+
+
+@then('the content of element with selector "{selector}" equals "{title}"')
+def content_equals_step(context, selector, title):
+    elem = context.browser.find_element_by_css_selector(selector).text
+    assert elem == title
+
+
+@then('the content of element with selector "{selector}" contains "{part}"')
+def content_contains_step(context, selector, part):
+    elem = context.browser.find_element_by_css_selector(selector).text
+    assert part in elem
+
+
+@then('the content of element with selector "{selector}" contains username')
+def content_contains_username_step(context, selector):
+    elem = context.browser.find_element_by_css_selector(selector).text
+    part = context.browser.header_overrides["e2e_username"]
+    assert part in elem
+
+
+@then('wait "{seconds}" seconds')
+def wait_step(context, seconds):
+    time.sleep(int(seconds))
+
+
+@then("we have a session cookie")
+def session_cookie_step(context):
+    cookie = context.browser.get_cookie("session")
+    assert cookie is not None

--- a/behave/requirements.txt
+++ b/behave/requirements.txt
@@ -1,3 +1,3 @@
--r requirements.txt
 behave==1.2.6
+requests==2.23.0
 selenium==3.141.0


### PR DESCRIPTION
Tests in `behave`

You can run locally. You need to set some env vars 
ENV_STAGING_ROOT_URL, ENV_STAGING_USERNAME and ENV_STAGING_PASSWORD 
for an account with no MFA. 

```
cd behave
make run
```

At the moment some of the targeting isn't great - I've added a task in the backlog to reformat the HTML a bit to make it easier to target content logically rather than by counting. 