### PR TITLE
Add groups to Cognito user

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-04-03T07:54:02Z",
+  "generated_at": "2020-04-06T11:34:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -60,7 +60,7 @@
         "hashed_secret": "dea742e166979027ae70b28e0a9006fb1010e760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 105,
         "type": "Secret Keyword"
       }
     ]

--- a/admin.py
+++ b/admin.py
@@ -6,8 +6,8 @@ from requests.utils import quote
 
 import cognito
 import s3paths
+from cognito_groups import return_users_group, user_groups
 from flask_helpers import render_template_custom
-from cognito_groups import user_groups, return_users_group
 
 local_valid_paths_var = []
 

--- a/admin.py
+++ b/admin.py
@@ -6,7 +6,7 @@ from requests.utils import quote
 
 import cognito
 import s3paths
-from cognito_groups import return_users_group, user_groups
+from cognito_groups import get_group_by_name, return_users_group, user_groups
 from flask_helpers import render_template_custom
 
 local_valid_paths_var = []
@@ -152,7 +152,7 @@ def admin_confirm_user(app):
                     phone_number=admin_user_object["phone_number"],
                     attr_paths=admin_user_object["custom:paths"],
                     is_la=admin_user_object["custom:is_la"],
-                    groupname=admin_user_object["group"],
+                    group_name=admin_user_object["group"]["value"],
                 )
 
                 clear_session(app)
@@ -172,7 +172,7 @@ def admin_confirm_user(app):
                     new_phone_number=admin_user_object["phone_number"],
                     new_paths=admin_user_object["custom:paths"].split(";"),
                     new_is_la=admin_user_object["custom:is_la"],
-                    new_groupname=admin_user_object["group"],
+                    new_group_name=admin_user_object["group"]["value"],
                 )
 
                 clear_session(app)
@@ -194,8 +194,9 @@ def admin_confirm_user(app):
     user["phone_number"] = sanitise_input(args, "telephone-number")
 
     account_type = sanitise_input(args, "account")
-    user_group = return_users_group({"group": account_type})
-    user["group"] = user_group["value"]
+    # user_group = return_users_group({"group": account_type})
+    user_group = get_group_by_name(account_type)
+    user["group"] = user_group
 
     san_is_la = sanitise_input(args, "is-la-radio") == "yes"
     if san_is_la:

--- a/admin.py
+++ b/admin.py
@@ -152,6 +152,7 @@ def admin_confirm_user(app):
                     phone_number=admin_user_object["phone_number"],
                     attr_paths=admin_user_object["custom:paths"],
                     is_la=admin_user_object["custom:is_la"],
+                    groupname=admin_user_object["group"],
                 )
 
                 clear_session(app)
@@ -171,6 +172,7 @@ def admin_confirm_user(app):
                     new_phone_number=admin_user_object["phone_number"],
                     new_paths=admin_user_object["custom:paths"].split(";"),
                     new_is_la=admin_user_object["custom:is_la"],
+                    new_groupname=admin_user_object["group"],
                 )
 
                 clear_session(app)
@@ -192,8 +194,8 @@ def admin_confirm_user(app):
     user["phone_number"] = sanitise_input(args, "telephone-number")
 
     account_type = sanitise_input(args, "account")
-    user_group = return_users_group({"groups": [account_type]})[0]
-    user["groups"] = account_group["value"]
+    user_group = return_users_group({"group": account_type})
+    user["group"] = user_group["value"]
 
     san_is_la = sanitise_input(args, "is-la-radio") == "yes"
     if san_is_la:

--- a/admin.py
+++ b/admin.py
@@ -109,37 +109,37 @@ def admin_confirm_user(app):
     elif "task" in args:
         task = args["task"]
 
-    print("admin_confirm_user:task:", task)
+    app.logger.debug("admin_confirm_user:task:", task)
 
     if task == "cancel-existing":
-        print("admin_confirm_user: redirecting back to user")
+        app.logger.debug("admin_confirm_user: redirecting back to user")
         return redirect("/admin/user")
 
     if task == "cancel-new":
         clear_session(app)
-        print("admin_confirm_user: redirecting back to admin")
+        app.logger.debug("admin_confirm_user: redirecting back to admin")
         return redirect("/admin")
 
     if task in ["edit-exiting", "edit-new"]:
-        print("admin_confirm_user: redirecting back to edit")
+        app.logger.debug("admin_confirm_user: redirecting back to edit")
         return redirect("/admin/user/edit")
 
     user = {}
     new_user = False
 
-    print("admin_confirm_user:args:", args)
+    app.logger.debug("admin_confirm_user:args:", args)
 
     if task in ["new", "continue-new"]:
         new_user = True
         if "email" in args:
             user = {"email": cognito.sanitise_email(args["email"])}
 
-    print("admin_confirm_user:user1:", user)
+    app.logger.debug("admin_confirm_user:user1:", user)
 
     if user == {}:
         user = admin_user_object
 
-    print("admin_confirm_user:user2:", user)
+    app.logger.debug("admin_confirm_user:user2:", user)
 
     if "frompage" in args:
         if "self" == args["frompage"]:

--- a/cognito.py
+++ b/cognito.py
@@ -9,7 +9,8 @@ import time
 
 import boto3
 from botocore.exceptions import ClientError
-from cognito_groups import user_groups, return_users_group
+
+from cognito_groups import return_users_group, user_groups
 
 # from validate_email import validate_email
 

--- a/cognito.py
+++ b/cognito.py
@@ -378,7 +378,7 @@ def add_user_to_group(username, group_name=None):
         group_name = "standard-download"
 
     group_map = get_group_map()
-    
+
     if group_name in group_map.keys():
         response = client.admin_add_user_to_group(
             UserPoolId=get_env_pool_id(), Username=username, GroupName=group_name

--- a/cognito.py
+++ b/cognito.py
@@ -11,7 +11,7 @@ import boto3
 from botocore.exceptions import ClientError
 from flask import session
 
-from cognito_groups import get_group_map, user_groups
+from cognito_groups import get_group_map, user_groups, get_group_by_name
 from logger import LOG
 
 # from validate_email import validate_email
@@ -208,9 +208,8 @@ def users_group(username):
     # return return_users_group(groups)
     # Currently you can attach a list of users in cognito
     # but we're currently only interested in the first group
-    group_map = get_group_map()
-    group_name = groups[0]
-    return group_map[group_name]
+    group_name = groups[0] if len(groups) > 0 else None
+    return get_group_by_name(group_name)
 
 
 def normalise_user(aws_user_resp):

--- a/cognito.py
+++ b/cognito.py
@@ -378,9 +378,7 @@ def add_user_to_group(username, group_name=None):
         group_name = "standard-download"
 
     group_map = get_group_map()
-    # group_list = create_and_list_groups()
-    # groups = [group["value"] for group in group_list]
-
+    
     if group_name in group_map.keys():
         response = client.admin_add_user_to_group(
             UserPoolId=get_env_pool_id(), Username=username, GroupName=group_name

--- a/cognito.py
+++ b/cognito.py
@@ -338,11 +338,13 @@ def create_and_list_groups():
     client = get_boto3_client()
 
     user_pool_group_names = []
-    lg_res = client.list_groups(UserPoolId=get_env_pool_id(), Limit=10)
-    if "ResponseMetadata" in lg_res:
-        if "HTTPStatusCode" in lg_res["ResponseMetadata"]:
-            if lg_res["ResponseMetadata"]["HTTPStatusCode"] == 200:
-                user_pool_group_names = [g["GroupName"] for g in response["Groups"]]
+    list_groups_response = client.list_groups(UserPoolId=get_env_pool_id(), Limit=10)
+    if "ResponseMetadata" in list_groups_response:
+        if "HTTPStatusCode" in list_groups_response["ResponseMetadata"]:
+            if list_groups_response["ResponseMetadata"]["HTTPStatusCode"] == 200:
+                user_pool_group_names = [
+                    group["GroupName"] for group in list_groups_response["Groups"]
+                ]
 
     if len(user_pool_group_names) == 0:
         return groups_res
@@ -385,9 +387,7 @@ def add_user_to_group(username, groupname=None):
     return False
 
 
-def create_user(
-    name, email_address, phone_number, attr_paths, is_la="0", groupname=None
-):
+def create_user(name, email_address, phone_number, attr_paths, is_la="0", group=None):
     client = get_boto3_client()
     email_address = sanitise_email(email_address)
     if email_address == "":
@@ -447,7 +447,7 @@ def create_user(
 
         time.sleep(0.1)
 
-        autg = add_user_to_group(email_address, group)
+        add_user_to_group(email_address, group)
 
     return res
 

--- a/cognito.py
+++ b/cognito.py
@@ -189,7 +189,7 @@ def get_user_details(email_address):
 
 
 def users_group(username):
-    grps = []
+    groups = []
 
     client = get_boto3_client()
     response = client.admin_list_groups_for_user(
@@ -197,11 +197,11 @@ def users_group(username):
     )
 
     if "Groups" in response:
-        for grp in response["Groups"]:
-            if "GroupName" in grp:
-                grps.append(grp["GroupName"])
+        for group in response["Groups"]:
+            if "GroupName" in group:
+                groups.append(group["GroupName"])
 
-    return return_users_group(grps)
+    return return_users_group(groups)
 
 
 def normalise_user(aws_user_resp):

--- a/cognito_groups.py
+++ b/cognito_groups.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+
+def user_groups(groupvalue=None):
+    groups = [
+        {
+            "preference": 10,
+            "value": "standard-download",
+            "display": "Standard download user",
+        },
+        {
+            "preference": 20,
+            "value": "standard-upload",
+            "display": "Standard download and upload user",
+        },
+        {
+            "preference": 70,
+            "value": "admin-view",
+            "display": "User administrator read-only",
+        },
+        {
+            "preference": 80,
+            "value": "admin-power",
+            "display": "User administrator power (reinvite/disable)",
+        },
+        {
+            "preference": 90,
+            "value": "admin-full",
+            "display": "User administrator full access",
+        },
+    ]
+
+    if groupvalue is not None:
+        for g in groups:
+            if groupvalue == g["value"]:
+                return [g]
+        return user_groups("standard-download")
+
+    return groups
+
+
+def return_users_group(user=None):
+    sel_group = user_groups("standard-download")[0]
+
+    start_pref = 1000
+    if user is not None and "groups" in user:
+        avail_groups = user_groups()
+        for ug in user["groups"]:
+            for ag in avail_groups:
+                if ug == ag["value"] and ag["preference"] < start_pref:
+                    sel_group = ag
+                    start_pref = ag["preference"]
+
+    return sel_group

--- a/cognito_groups.py
+++ b/cognito_groups.py
@@ -31,9 +31,9 @@ def user_groups(groupvalue=None):
     ]
 
     if groupvalue is not None:
-        for g in groups:
-            if groupvalue == g["value"]:
-                return [g]
+        for group in groups:
+            if groupvalue == group["value"]:
+                return [group]
         return user_groups("standard-download")
 
     return groups
@@ -43,9 +43,9 @@ def return_users_group(user=None):
     sel_group = user_groups("standard-download")[0]
 
     if user is not None and "group" in user:
-        for ugs in user_groups():
-            if user["group"] == ugs["value"]:
-                sel_group = ugs
+        for group in user_groups():
+            if user["group"] == group["value"]:
+                sel_group = group
                 break
 
     return sel_group

--- a/cognito_groups.py
+++ b/cognito_groups.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-def user_groups(groupvalue=None):
+def get_group_list():
     groups = [
         {
             "preference": 10,
@@ -29,10 +29,26 @@ def user_groups(groupvalue=None):
             "display": "User administrator full access",
         },
     ]
+    return groups
 
-    if groupvalue is not None:
+
+def get_group_map():
+    group_list = get_group_list()
+    group_map = {group["value"]: group for group in group_list}
+    return group_map
+
+
+def get_group_by_name(group_name):
+    group_map = get_group_map()
+    return group_map[group_name]
+
+
+def user_groups(group_value=None):
+    groups = get_group_list()
+
+    if group_value is not None:
         for group in groups:
-            if groupvalue == group["value"]:
+            if group_value == group["value"]:
                 return [group]
         return user_groups("standard-download")
 
@@ -40,12 +56,16 @@ def user_groups(groupvalue=None):
 
 
 def return_users_group(user=None):
-    sel_group = user_groups("standard-download")[0]
+    """
+    Return the users current group or the default
+    group for new users if not specified
+    """
 
-    if user is not None and "group" in user:
-        for group in user_groups():
-            if user["group"] == group["value"]:
-                sel_group = group
-                break
-
-    return sel_group
+    default_group_name = "standard-download"
+    group_map = get_group_map()
+    default_group = group_map[default_group_name]
+    try:
+        group = user.get("group", default_group)
+    except (ValueError, KeyError, AttributeError):
+        group = default_group
+    return group

--- a/cognito_groups.py
+++ b/cognito_groups.py
@@ -39,6 +39,8 @@ def get_group_map():
 
 
 def get_group_by_name(group_name):
+    if group_name is None:
+        group_name = "standard-download"
     group_map = get_group_map()
     return group_map[group_name]
 

--- a/cognito_groups.py
+++ b/cognito_groups.py
@@ -2,40 +2,40 @@
 
 
 def get_group_list():
-    groups = [
-        {
-            "preference": 10,
-            "value": "standard-download",
-            "display": "Standard download user",
-        },
-        {
-            "preference": 20,
-            "value": "standard-upload",
-            "display": "Standard download and upload user",
-        },
-        {
-            "preference": 70,
-            "value": "admin-view",
-            "display": "User administrator read-only",
-        },
-        {
-            "preference": 80,
-            "value": "admin-power",
-            "display": "User administrator power (reinvite/disable)",
-        },
-        {
-            "preference": 90,
-            "value": "admin-full",
-            "display": "User administrator full access",
-        },
-    ]
+    group_map = get_group_map()
+    groups = group_map.values()
     return groups
 
 
 def get_group_map():
-    group_list = get_group_list()
-    group_map = {group["value"]: group for group in group_list}
-    return group_map
+    groups = {
+        "standard-download": {
+            "preference": 10,
+            "value": "standard-download",
+            "display": "Standard download user",
+        },
+        "standard-upload": {
+            "preference": 20,
+            "value": "standard-upload",
+            "display": "Standard download and upload user",
+        },
+        "admin-view": {
+            "preference": 70,
+            "value": "admin-view",
+            "display": "User administrator read-only",
+        },
+        "admin-power": {
+            "preference": 80,
+            "value": "admin-power",
+            "display": "User administrator power (reinvite/disable)",
+        },
+        "admin-full": {
+            "preference": 90,
+            "value": "admin-full",
+            "display": "User administrator full access",
+        },
+    }
+    return groups
 
 
 def get_group_by_name(group_name):

--- a/cognito_groups.py
+++ b/cognito_groups.py
@@ -42,13 +42,10 @@ def user_groups(groupvalue=None):
 def return_users_group(user=None):
     sel_group = user_groups("standard-download")[0]
 
-    start_pref = 1000
-    if user is not None and "groups" in user:
-        avail_groups = user_groups()
-        for ug in user["groups"]:
-            for ag in avail_groups:
-                if ug == ag["value"] and ag["preference"] < start_pref:
-                    sel_group = ag
-                    start_pref = ag["preference"]
+    if user is not None and "group" in user:
+        for ugs in user_groups():
+            if user["group"] == ugs["value"]:
+                sel_group = ugs
+                break
 
     return sel_group

--- a/conftest.py
+++ b/conftest.py
@@ -58,3 +58,21 @@ def test_client():
     yield testing_client  # this is where the testing happens!
 
     ctx.pop()
+
+
+@pytest.fixture()
+def standard_download():
+    return {
+        "preference": 10,
+        "value": "standard-download",
+        "display": "Standard download user",
+    }
+
+
+@pytest.fixture()
+def standard_upload():
+    return {
+        "preference": 20,
+        "value": "standard-upload",
+        "display": "Standard download and upload user",
+    }

--- a/css/main.css
+++ b/css/main.css
@@ -1,1 +1,2 @@
 .red-admin { background: #d21717 !important; }
+.hidden { display: none !important; }

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -35,6 +35,7 @@ def login_required(f):
 
 def render_template_custom(app, template, hide_logout=False, **args):
     args["is_admin_interface"] = is_admin_interface()
+    show_back_link =  template not in ["welcome.html","login.html"]
 
     show_logout = False
     display_username = ""
@@ -42,6 +43,7 @@ def render_template_custom(app, template, hide_logout=False, **args):
         show_logout = True
         display_username = session["email"]
 
+    args["show_back_link"] = show_back_link
     args["show_logout"] = show_logout
     args["display_username"] = display_username
 

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -33,8 +33,17 @@ def login_required(f):
     return decorated_function
 
 
-def render_template_custom(app, template, **args):
+def render_template_custom(app, template, hide_logout=False, **args):
     args["is_admin_interface"] = is_admin_interface()
+
+    show_logout = False
+    display_username = ""
+    if "details" in session and not hide_logout:
+        show_logout = True
+        display_username = session["email"]
+
+    args["show_logout"] = show_logout
+    args["display_username"] = display_username
 
     page_title = os.getenv("PAGE_TITLE", "GOV.UK")
     if is_development():

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -35,7 +35,7 @@ def login_required(f):
 
 def render_template_custom(app, template, hide_logout=False, **args):
     args["is_admin_interface"] = is_admin_interface()
-    show_back_link =  template not in ["welcome.html","login.html"]
+    show_back_link = template not in ["welcome.html", "login.html"]
 
     show_logout = False
     display_username = ""

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,7 @@ document.body.className = ((document.body.className) ? document.body.className +
 window.GOVUKFrontend.initAll();
 
 load_is_la_radio_js();
+load_account_switch_js();
 
 function load_is_la_radio_js() {
   console.log("load_is_la_radio_js");
@@ -12,6 +13,21 @@ function load_is_la_radio_js() {
       is_la_switch(x[i].value);
     }
     x[i].addEventListener('change', function() { is_la_switch(this.value); });
+  }
+}
+
+function load_account_switch_js() {
+  console.log("load_account_switch_js");
+  var x = document.getElementById("account-select");
+  x.addEventListener('change', function() { account_switch(this.value); });
+}
+
+function account_switch(s) {
+  var is_admin = (s.indexOf("admin-") === 0)
+  if (is_admin) {
+    document.getElementById("standard-user-inputs").classList.add("hidden");
+  } else {
+    document.getElementById("standard-user-inputs").classList.remove("hidden");
   }
 }
 

--- a/main.py
+++ b/main.py
@@ -162,19 +162,19 @@ def send_browser_config():
 @app.errorhandler(500)
 def server_error_500(e):
     app.logger.error(f"Server error: {request.url}")
-    return render_template_custom(app, "error.html", error=e), 500
+    return render_template_custom(app, "error.html", hide_logout=True, error=e), 500
 
 
 @app.errorhandler(404)
 def server_error_404(e):
     app.logger.error(f"Server error: {request.url}")
-    return render_template_custom(app, "error.html", error=e), 404
+    return render_template_custom(app, "error.html", hide_logout=True, error=e), 404
 
 
 @app.errorhandler(400)
 def server_error_400(e):
     app.logger.error(f"Server error: {request.url}")
-    return render_template_custom(app, "error.html", error=e), 400
+    return render_template_custom(app, "error.html", hide_logout=True, error=e), 400
 
 
 @app.route("/")
@@ -208,7 +208,9 @@ def index():
             f"redirect_uri={app.redirect_host}&"
             "scope=profile+email+phone+openid+aws.cognito.signin.user.admin"
         )
-        return render_template_custom(app, "login.html", login_url=login_url)
+        return render_template_custom(
+            app, "login.html", login_url=login_url, hide_logout=True
+        )
 
 
 @app.route("/logout")
@@ -259,16 +261,13 @@ def download():
 @app.route("/files")
 @login_required
 def files():
-    if "details" in session and "attributes" in session:
-        files = get_files(app.bucket_name, session)
+    files = get_files(app.bucket_name, session)
 
-        # TODO sorting
+    # TODO sorting
 
-        return render_template_custom(
-            app, "files.html", user=session["user"], email=session["email"], files=files
-        )
-    else:
-        return redirect("/")
+    return render_template_custom(
+        app, "files.html", user=session["user"], email=session["email"], files=files
+    )
 
 
 # ----------- ADMIN ROUTES -----------

--- a/templates/admin/confirm-user.html
+++ b/templates/admin/confirm-user.html
@@ -28,6 +28,14 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
+      Account type
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">{{ user_group['display'] }}</p>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
       Local authority user?
     </dt>
     <dd class="govuk-summary-list__value">

--- a/templates/admin/edit-user.html
+++ b/templates/admin/edit-user.html
@@ -34,95 +34,113 @@
   </div>
 
   <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset" aria-describedby="is-la-radio-hint">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-        <h1 class="govuk-fieldset__heading">
-          Local authority user?
-        </h1>
-      </legend>
-      <div class="govuk-radios govuk-radios--inline">
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="is-la-radio" name="is-la-radio" type="radio" value="yes" {{ 'checked="checked"' if is_la }}>
-          <label class="govuk-label govuk-radios__label" for="is-la-radio">
-            Yes
-          </label>
-        </div>
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="is-la-radio-2" name="is-la-radio" type="radio" value="no" {{ 'checked="checked"' if not is_la }}>
-          <label class="govuk-label govuk-radios__label" for="is-la-radio-2">
-            No
-          </label>
-        </div>
-      </div>
-    </fieldset>
-  </div>
-
-  <div class="govuk-form-group">
     <fieldset class="govuk-fieldset" aria-describedby="la_cond-hint">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
         <h1 class="govuk-fieldset__heading">
-          Type of account and access
+          Account type
         </h1>
       </legend>
-      <span id="la_cond-hint" class="govuk-hint">
-        Select one option.
-      </span>
-      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="other_cond" type="radio" data-aria-controls="conditional-other_cond" {{ 'checked="checked"' if is_other }} aria-expanded="true">
-          <label class="govuk-label govuk-radios__label" for="other_cond">
-            Other
-          </label>
-        </div>
-        <div class="govuk-radios__conditional govuk-radios__conditional" id="conditional-other_cond">
-          <div class="govuk-form-group">
-            <div class="govuk-checkboxes">
-              {% for i in other.subs %}
-              <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" name="custom_paths" type="checkbox" value="{{ i['val'] }}" {{
-                  'checked="checked"' if i['val'] in user_custom_paths
-                }}>
-                <label class="govuk-label govuk-checkboxes__label" for="custom_paths">
-                  {{ i['disp'] }}<br>
-                  <span class="govuk-hint">
-                    {{ i['val'] }}
-                  </span>
-                </label>
-              </div>
-              {% endfor %}
-            </div>
-          </div>
-        </div>
-
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="la_cond" type="radio" data-aria-controls="conditional-la_cond" {{ 'checked="checked"' if is_la }}>
-          <label class="govuk-label govuk-radios__label" for="la_cond">
-            Local authority
-          </label>
-        </div>
-        <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-la_cond">
-          <div class="govuk-form-group">
-            <div class="govuk-checkboxes">
-              {% for i in local_authority.subs %}
-              <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" name="custom_paths" type="checkbox" value="{{ i['val'] }}" {{
-                  'checked="checked"' if i['val'] in user_custom_paths
-                }}>
-                <label class="govuk-label govuk-checkboxes__label" for="custom_paths">
-                  {{ i['disp'] }}<br>
-                  <span class="govuk-hint">
-                    {{ i['val'] }}
-                  </span>
-                </label>
-              </div>
-              {% endfor %}
-            </div>
-          </div>
-        </div>
-
-      </div>
+      <select class="govuk-select" id="account-select" name="account">
+        <option value="standard-download" selected>Standard download user</option>
+        <option value="standard-upload">Standard download and upload user</option>
+        <option value="admin-view">User administrator read-only</option>
+        <option value="admin-power">User administrator power (reinvite/disable)</option>
+        <option value="admin-full">User administrator full access</option>
+      </select>
     </fieldset>
+  </div>
+
+  <div id="standard-user-inputs">
+
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset" aria-describedby="is-la-radio-hint">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h1 class="govuk-fieldset__heading">
+            Local authority user?
+          </h1>
+        </legend>
+        <div class="govuk-radios govuk-radios--inline">
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="is-la-radio" name="is-la-radio" type="radio" value="yes" {{ 'checked="checked"' if is_la }}>
+            <label class="govuk-label govuk-radios__label" for="is-la-radio">
+              Yes
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="is-la-radio-2" name="is-la-radio" type="radio" value="no" {{ 'checked="checked"' if not is_la }}>
+            <label class="govuk-label govuk-radios__label" for="is-la-radio-2">
+              No
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset" aria-describedby="la_cond-hint">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h1 class="govuk-fieldset__heading">
+            Available download areas
+          </h1>
+        </legend>
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="other_cond" type="radio" data-aria-controls="conditional-other_cond" {{ 'checked="checked"' if is_other }} aria-expanded="true">
+            <label class="govuk-label govuk-radios__label" for="other_cond">
+              Other
+            </label>
+          </div>
+          <div class="govuk-radios__conditional govuk-radios__conditional" id="conditional-other_cond">
+            <div class="govuk-form-group">
+              <div class="govuk-checkboxes">
+                {% for i in other.subs %}
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" name="custom_paths" type="checkbox" value="{{ i['val'] }}" {{
+                    'checked="checked"' if i['val'] in user_custom_paths
+                  }}>
+                  <label class="govuk-label govuk-checkboxes__label" for="custom_paths">
+                    {{ i['disp'] }}<br>
+                    <span class="govuk-hint">
+                      {{ i['val'] }}
+                    </span>
+                  </label>
+                </div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="la_cond" type="radio" data-aria-controls="conditional-la_cond" {{ 'checked="checked"' if is_la }}>
+            <label class="govuk-label govuk-radios__label" for="la_cond">
+              Local authority
+            </label>
+          </div>
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-la_cond">
+            <div class="govuk-form-group">
+              <div class="govuk-checkboxes">
+                {% for i in local_authority.subs %}
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" name="custom_paths" type="checkbox" value="{{ i['val'] }}" {{
+                    'checked="checked"' if i['val'] in user_custom_paths
+                  }}>
+                  <label class="govuk-label govuk-checkboxes__label" for="custom_paths">
+                    {{ i['disp'] }}<br>
+                    <span class="govuk-hint">
+                      {{ i['val'] }}
+                    </span>
+                  </label>
+                </div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </fieldset>
+    </div>
+
   </div>
 
   <div>

--- a/templates/admin/edit-user.html
+++ b/templates/admin/edit-user.html
@@ -19,8 +19,8 @@
     <span class="govuk-hint">
       <br>
       The following email addresses are allowed:
-      {% for d in allowed_domains %}
-      <pre>*{{ d }}</pre>
+      {% for domain in allowed_domains %}
+      <pre>*{{ domain }}</pre>
       {% endfor %}
     </span>
     {% endif %}
@@ -36,13 +36,13 @@
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset" aria-describedby="la_cond-hint">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-        <h1 class="govuk-fieldset__heading">
+        <h2 class="govuk-fieldset__heading">
           Account type
-        </h1>
+        </h2>
       </legend>
       <select class="govuk-select" id="account-select" name="account">
-        {% for g in available_groups %}
-        <option value="{{ g['value'] }}" selected>{{ g['display'] }}</option>
+        {% for group in available_groups %}
+        <option value="{{ group['value'] }}" {% if user['group']['value'] == group['value'] %} selected {% endif %}>{{ group['display'] }}</option>
         {% endfor %}
       </select>
     </fieldset>
@@ -53,9 +53,9 @@
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset" aria-describedby="is-la-radio-hint">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          <h1 class="govuk-fieldset__heading">
+          <h2 class="govuk-fieldset__heading">
             Local authority user?
-          </h1>
+          </h2>
         </legend>
         <div class="govuk-radios govuk-radios--inline">
           <div class="govuk-radios__item">
@@ -77,9 +77,9 @@
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset" aria-describedby="la_cond-hint">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          <h1 class="govuk-fieldset__heading">
+          <h2 class="govuk-fieldset__heading">
             Available download areas
-          </h1>
+          </h2>
         </legend>
         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
 

--- a/templates/admin/edit-user.html
+++ b/templates/admin/edit-user.html
@@ -42,7 +42,7 @@
       </legend>
       <select class="govuk-select" id="account-select" name="account">
         {% for group in available_groups %}
-        <option value="{{ group['value'] }}" {% if user['group']['value'] == group['value'] %} selected {% endif %}>{{ group['display'] }}</option>
+        <option value="{{ group['value'] }}" {% if "group" in user and user["group"]["value"] == group["value"] %} selected {% endif %}>{{ group['display'] }}</option>
         {% endfor %}
       </select>
     </fieldset>

--- a/templates/admin/edit-user.html
+++ b/templates/admin/edit-user.html
@@ -41,11 +41,9 @@
         </h1>
       </legend>
       <select class="govuk-select" id="account-select" name="account">
-        <option value="standard-download" selected>Standard download user</option>
-        <option value="standard-upload">Standard download and upload user</option>
-        <option value="admin-view">User administrator read-only</option>
-        <option value="admin-power">User administrator power (reinvite/disable)</option>
-        <option value="admin-full">User administrator full access</option>
+        {% for g in available_groups %}
+        <option value="{{ g['value'] }}" selected>{{ g['display'] }}</option>
+        {% endfor %}
       </select>
     </fieldset>
   </div>

--- a/templates/admin/user.html
+++ b/templates/admin/user.html
@@ -56,15 +56,10 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      User groups
+      Account type
     </dt>
     <dd class="govuk-summary-list__value">
-      {% if user["groups"]|length == 0 %}
-        <p class="govuk-body">Standard download user</p>
-      {% endif %}
-      {% for grp in user["groups"] %}
-        <p class="govuk-body">{{ grp }}</p>
-      {% endfor %}
+      <p class="govuk-body">{{ user_group['display'] }}</p>
     </dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/templates/admin/user.html
+++ b/templates/admin/user.html
@@ -56,6 +56,19 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
+      User groups
+    </dt>
+    <dd class="govuk-summary-list__value">
+      {% if user["groups"]|length == 0 %}
+        <p class="govuk-body">Standard download user</p>
+      {% endif %}
+      {% for grp in user["groups"] %}
+        <p class="govuk-body">{{ grp }}</p>
+      {% endfor %}
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
       Local authority user?
     </dt>
     <dd class="govuk-summary-list__value">

--- a/templates/error.html
+++ b/templates/error.html
@@ -3,8 +3,6 @@
 
   <h1 class="govuk-heading-xl">Error</h1>
 
-  <a href="/" class="govuk-back-link">Back</a>
-
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
       There is a problem

--- a/templates/files.html
+++ b/templates/files.html
@@ -4,18 +4,6 @@
   <a href="/" class="govuk-back-link">Back</a>
 
   <p>
-    You're currently logged in as
-    <span class="covid-transfer-username">{{ user }}</span>.
-  </p>
-  <p>
-    <a href="/logout" class="covid-transfer-logout-button">
-      <button class="govuk-button govuk-button--secondary" data-module="govuk-button" title="Logout">
-        Logout
-      </button>
-    </a>
-  </p>
-
-  <p>
     <a href="/files" role="button" draggable="false" class="govuk-button covid-transfer-reload-button" data-module="govuk-button">
       Reload
     </a>
@@ -40,7 +28,7 @@
       {% elif files|length == 1 %}
         There is 1 file available to download:
       {% else %}
-        There are {{ files|length }} file(s) available to download:
+        There are {{ files|length }} files available to download:
       {% endif %}
     </div>
 

--- a/templates/files.html
+++ b/templates/files.html
@@ -1,8 +1,6 @@
 {% extends 'primary.html' %}
 {% block content %}
 
-  <a href="/" class="govuk-back-link">Back</a>
-
   <p>
     <a href="/files" role="button" draggable="false" class="govuk-button covid-transfer-reload-button" data-module="govuk-button">
       Reload

--- a/templates/primary.html
+++ b/templates/primary.html
@@ -42,7 +42,7 @@
     <script src="/dist/html5shiv.min.js"></script>
   <![endif]-->
 
-  <link href="/css/main.css" rel="stylesheet">
+  <link href="/css/main.css?update=202004031810" rel="stylesheet">
 
   <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
 </head>
@@ -90,6 +90,17 @@
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
 
       <h1 class="govuk-heading-xl covid-transfer-page-title">{{ title }}</h1>
+      {% if show_logout %}
+        <p>
+          You're currently logged in as
+          <span class="covid-transfer-username">{{ display_username }}</span>.
+        </p>
+        <p>
+          <a href="/logout" class="covid-transfer-logout-button">
+            <button class="govuk-button govuk-button--secondary" data-module="govuk-button" title="Logout">Logout</button>
+          </a>
+        </p>
+      {% endif %}
       {% block content %}{% endblock %}
     </main>
   </div>
@@ -115,7 +126,7 @@
   </footer>
 
   <script src="/js/govuk-frontend-3.6.0.min.js"></script>
-  <script src="/js/main.js?update=202004022151"></script>
+  <script src="/js/main.js?update=202004031812"></script>
 
 </body>
 </html>

--- a/templates/primary.html
+++ b/templates/primary.html
@@ -89,7 +89,12 @@
 
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
 
+
       <h1 class="govuk-heading-xl covid-transfer-page-title">{{ title }}</h1>
+      {% if show_back_link %}
+      <a href="/" class="govuk-back-link">Back</a>
+      {% endif %}
+
       {% if show_logout %}
         <p>
           You're currently logged in as

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -1,18 +1,6 @@
 {% extends 'primary.html' %}
 {% block content %}
 
-  <p class="covid-transfer-welcome-text">
-    You're currently logged in as
-    <span class="covid-transfer-username">{{ user }}</span>.
-  </p>
-  <p>
-    <a href="/logout" class="covid-transfer-logout-button">
-      <button class="govuk-button govuk-button--secondary" data-module="govuk-button" title="Logout">
-        Logout
-      </button>
-    </a>
-  </p>
-
   <p>
     This service allows you to access data on people who have asked for help and who are considered medically vulnerable to a COVID-19 infection.
   </p>

--- a/tests/test_cognito_groups.py
+++ b/tests/test_cognito_groups.py
@@ -1,0 +1,47 @@
+from cognito_groups import return_users_group, user_groups
+
+
+fixture_standard_download = {
+    "preference": 10,
+    "value": "standard-download",
+    "display": "Standard download user",
+}
+
+fixture_standard_upload = {
+    "preference": 20,
+    "value": "standard-upload",
+    "display": "Standard download and upload user",
+}
+
+
+def test_user_groups():
+
+    assert len(user_groups()) == 5
+
+    bad_group = user_groups("admin")
+    assert len(bad_group) == 1
+    assert bad_group[0] == fixture_standard_download
+
+    good_group = user_groups("standard-upload")
+    assert len(good_group) == 1
+    assert good_group[0] == fixture_standard_upload
+
+
+def test_return_users_group():
+
+    assert return_users_group() == fixture_standard_download
+    assert return_users_group({}) == fixture_standard_download
+    assert return_users_group({"groups": []}) == fixture_standard_download
+    assert return_users_group({"groups": [""]}) == fixture_standard_download
+
+    assert (
+        return_users_group({"groups": ["standard-upload"]}) == fixture_standard_upload
+    )
+    assert (
+        return_users_group({"groups": ["standard-download", "standard-upload"]})
+        == fixture_standard_download
+    )
+    assert (
+        return_users_group({"groups": ["standard-upload", "standard-download"]})
+        == fixture_standard_download
+    )

--- a/tests/test_cognito_groups.py
+++ b/tests/test_cognito_groups.py
@@ -24,8 +24,6 @@ def test_return_users_group(standard_download, standard_upload):
 
     assert return_users_group() == standard_download
     assert return_users_group({}) == standard_download
-    assert return_users_group({"group": []}) == standard_download
-    assert return_users_group({"group": [""]}) == standard_download
 
-    assert return_users_group({"group": "standard-upload"}) == standard_upload
-    assert return_users_group({"group": "standard-download"}) == standard_download
+    assert return_users_group({"group": standard_upload}) == standard_upload
+    assert return_users_group({"group": standard_download}) == standard_download

--- a/tests/test_cognito_groups.py
+++ b/tests/test_cognito_groups.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cognito_groups import (
+    get_group_by_name,
     get_group_list,
     get_group_map,
     return_users_group,
@@ -27,6 +28,17 @@ def test_get_group_list(standard_download, standard_upload):
     assert len(group_list) == 5
     assert standard_download in group_list
     assert standard_upload in group_list
+
+
+@pytest.mark.usefixtures("standard_download")
+@pytest.mark.usefixtures("standard_upload")
+def test_get_group_by_name(standard_download, standard_upload):
+
+    group = get_group_by_name("standard-download")
+    assert group == standard_download
+
+    group = get_group_by_name("standard-upload")
+    assert group == standard_upload
 
 
 @pytest.mark.usefixtures("standard_download")

--- a/tests/test_cognito_groups.py
+++ b/tests/test_cognito_groups.py
@@ -1,6 +1,5 @@
 from cognito_groups import return_users_group, user_groups
 
-
 fx_standard_download = {
     "preference": 10,
     "value": "standard-download",

--- a/tests/test_cognito_groups.py
+++ b/tests/test_cognito_groups.py
@@ -1,37 +1,31 @@
+import pytest
+
 from cognito_groups import return_users_group, user_groups
 
-fx_standard_download = {
-    "preference": 10,
-    "value": "standard-download",
-    "display": "Standard download user",
-}
 
-fx_standard_upload = {
-    "preference": 20,
-    "value": "standard-upload",
-    "display": "Standard download and upload user",
-}
-
-
-def test_user_groups():
+@pytest.mark.usefixtures("standard_download")
+@pytest.mark.usefixtures("standard_upload")
+def test_user_groups(standard_download, standard_upload):
 
     assert len(user_groups()) == 5
 
     bad_group = user_groups("admin")
     assert len(bad_group) == 1
-    assert bad_group[0] == fx_standard_download
+    assert bad_group[0] == standard_download
 
     good_group = user_groups("standard-upload")
     assert len(good_group) == 1
-    assert good_group[0] == fx_standard_upload
+    assert good_group[0] == standard_upload
 
 
-def test_return_users_group():
+@pytest.mark.usefixtures("standard_download")
+@pytest.mark.usefixtures("standard_upload")
+def test_return_users_group(standard_download, standard_upload):
 
-    assert return_users_group() == fx_standard_download
-    assert return_users_group({}) == fx_standard_download
-    assert return_users_group({"group": []}) == fx_standard_download
-    assert return_users_group({"group": [""]}) == fx_standard_download
+    assert return_users_group() == standard_download
+    assert return_users_group({}) == standard_download
+    assert return_users_group({"group": []}) == standard_download
+    assert return_users_group({"group": [""]}) == standard_download
 
-    assert return_users_group({"group": "standard-upload"}) == fx_standard_upload
-    assert return_users_group({"group": "standard-download"}) == fx_standard_download
+    assert return_users_group({"group": "standard-upload"}) == standard_upload
+    assert return_users_group({"group": "standard-download"}) == standard_download

--- a/tests/test_cognito_groups.py
+++ b/tests/test_cognito_groups.py
@@ -1,13 +1,13 @@
 from cognito_groups import return_users_group, user_groups
 
 
-fixture_standard_download = {
+fx_standard_download = {
     "preference": 10,
     "value": "standard-download",
     "display": "Standard download user",
 }
 
-fixture_standard_upload = {
+fx_standard_upload = {
     "preference": 20,
     "value": "standard-upload",
     "display": "Standard download and upload user",
@@ -20,28 +20,19 @@ def test_user_groups():
 
     bad_group = user_groups("admin")
     assert len(bad_group) == 1
-    assert bad_group[0] == fixture_standard_download
+    assert bad_group[0] == fx_standard_download
 
     good_group = user_groups("standard-upload")
     assert len(good_group) == 1
-    assert good_group[0] == fixture_standard_upload
+    assert good_group[0] == fx_standard_upload
 
 
 def test_return_users_group():
 
-    assert return_users_group() == fixture_standard_download
-    assert return_users_group({}) == fixture_standard_download
-    assert return_users_group({"groups": []}) == fixture_standard_download
-    assert return_users_group({"groups": [""]}) == fixture_standard_download
+    assert return_users_group() == fx_standard_download
+    assert return_users_group({}) == fx_standard_download
+    assert return_users_group({"group": []}) == fx_standard_download
+    assert return_users_group({"group": [""]}) == fx_standard_download
 
-    assert (
-        return_users_group({"groups": ["standard-upload"]}) == fixture_standard_upload
-    )
-    assert (
-        return_users_group({"groups": ["standard-download", "standard-upload"]})
-        == fixture_standard_download
-    )
-    assert (
-        return_users_group({"groups": ["standard-upload", "standard-download"]})
-        == fixture_standard_download
-    )
+    assert return_users_group({"group": "standard-upload"}) == fx_standard_upload
+    assert return_users_group({"group": "standard-download"}) == fx_standard_download

--- a/tests/test_cognito_groups.py
+++ b/tests/test_cognito_groups.py
@@ -1,6 +1,32 @@
 import pytest
 
-from cognito_groups import return_users_group, user_groups
+from cognito_groups import (
+    get_group_list,
+    get_group_map,
+    return_users_group,
+    user_groups,
+)
+
+
+@pytest.mark.usefixtures("standard_download")
+@pytest.mark.usefixtures("standard_upload")
+def test_get_group_map(standard_download, standard_upload):
+
+    group_map = get_group_map()
+    assert len(group_map.keys()) == 5
+    assert group_map["standard-download"] == standard_download
+    assert group_map["standard-upload"] == standard_upload
+
+
+@pytest.mark.usefixtures("standard_download")
+@pytest.mark.usefixtures("standard_upload")
+def test_get_group_list(standard_download, standard_upload):
+
+    group_list = get_group_list()
+
+    assert len(group_list) == 5
+    assert standard_download in group_list
+    assert standard_upload in group_list
 
 
 @pytest.mark.usefixtures("standard_download")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -62,7 +62,9 @@ def test_route_index_logged_in(test_client, test_session):
 
     assert response.status_code == 200
     assert "You're currently logged in as" in body
-    assert '<span class="covid-transfer-username">test-user@test-domain.com</span>' in body
+    assert (
+        '<span class="covid-transfer-username">test-user@test-domain.com</span>' in body
+    )
 
 
 @pytest.mark.usefixtures("test_client")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,10 +59,10 @@ def test_route_index_logged_in(test_client, test_session):
         app.logger.debug(test_session)
     response = test_client.get("/")
     body = response.data.decode()
-    # print(body)
+
     assert response.status_code == 200
     assert "You're currently logged in as" in body
-    assert '<span class="covid-transfer-username">test-user</span>' in body
+    assert '<span class="covid-transfer-username">test-user@test-domain.com</span>' in body
 
 
 @pytest.mark.usefixtures("test_client")


### PR DESCRIPTION
## Work in progress - adding groups functionality to front end and admin tool

This is to add user groups to the front end and admin app.

New required permissions for the front end app:
- `cognito-idp:AdminListGroupsForUser`
  - _for getting groups by username_
- `cognito-idp:ListUserPools` 
  - _for getting groups and to replace env vars, for setting the app settings dynamically_
- `cognito-idp:ListUserPoolClients`
  -  _replace env vars, for setting the app settings dynamically_
- `cognito-idp:DescribeUserPool` 
  - _replace env vars, for setting the app settings dynamically_
- `cognito-idp:DescribeUserPoolClient` 
  - _replace env vars, for setting the app settings dynamically_
- `ssm:GetParametersByPath` 
  - _replace env vars, for getting the bucket name_
- `ssm:GetParameter` 
  - _replace env vars, for getting the bucket name_

New required permissions for admin tool:
- `cognito-idp:AdminAddUserToGroup`
  - _for adding a user to a group_
- `cognito-idp:AdminRemoveUserFromGroup`
  - _for removing a user from a group_
- `cognito-idp:CreateGroup`
  - _for creating a group if it doesn't exist_