### PR TITLE
Refactor and unit test upload route

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,32 @@ def test_session():
 
 
 @pytest.fixture()
+def test_upload_session():
+    user_paths = (
+        "web-app-prod-data/local_authority/haringey;"
+        "web-app-prod-data/local_authority/barnet"
+    )
+    session = {
+        "details": {
+            "user": "test-user@test-domain.com",
+            "email": "test-user@test-domain.com",
+        },
+        "user": "test-user@test-domain.com",
+        "email": "test-user@test-domain.com",
+        "attributes": [
+            {"Name": "custom:is_la", "Value": "1"},
+            {"Name": "custom:paths", "Value": user_paths},
+        ],
+        "group": {
+            "preference": 20,
+            "value": "standard-upload",
+            "display": "Standard download and upload user",
+        },
+    }
+    return session
+
+
+@pytest.fixture()
 def test_jwt():
     return get_test_jwt()
 

--- a/conftest.py
+++ b/conftest.py
@@ -110,3 +110,17 @@ def standard_upload():
         "value": "standard-upload",
         "display": "Standard download and upload user",
     }
+
+
+@pytest.fixture()
+def upload_form_fields():
+    return {
+        "file_location": "web-app-upload/local_authority/haringey",
+        "file_name": "test_upload",
+        "file_ext": "csv",
+    }
+
+
+@pytest.fixture()
+def valid_extensions():
+    return {"csv": {"ext": "csv", "display": "CSV"}}

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -12,23 +12,33 @@ def is_development():
     return os.getenv("FLASK_ENV", "production") == "development"
 
 
-def admin_interface(f):
-    @wraps(f)
+def admin_interface(flask_route):
+    @wraps(flask_route)
     def decorated_function(*args, **kwargs):
 
         if not is_admin_interface():
             raise Exception("ADMIN not set when trying /admin")
-        return f(*args, **kwargs)
+        return flask_route(*args, **kwargs)
 
     return decorated_function
 
 
-def login_required(f):
-    @wraps(f)
+def login_required(flask_route):
+    @wraps(flask_route)
     def decorated_function(*args, **kwargs):
         if "details" not in session:
             return redirect("/")
-        return f(*args, **kwargs)
+        return flask_route(*args, **kwargs)
+
+    return decorated_function
+
+
+def upload_rights_required(flask_route):
+    @wraps(flask_route)
+    def decorated_function(*args, **kwargs):
+        if not has_upload_rights():
+            return redirect("/")
+        return flask_route(*args, **kwargs)
 
     return decorated_function
 

--- a/js/s3upload.js
+++ b/js/s3upload.js
@@ -49,7 +49,7 @@ function filename_change() {
     }
     let fev = fs.file_ext.value;
 
-    var new_filename_display = "web-app-upload/" + flv + "/" + cds + "_" + fnv.trim() + "." + fev;
+    var new_filename_display = flv + "/" + cds + "_" + fnv.trim() + "." + fev;
 
     var dfp = document.getElementById("dynamic_file_path");
     dfp.innerText = new_filename_display;

--- a/js/s3upload.js
+++ b/js/s3upload.js
@@ -13,10 +13,10 @@ function load_s3upload_js() {
 
   var fs = get_file_settings()
   if (fs !== false) {
-    fs.file_location.addEventListener('change', filename_change);
-    fs.filename.addEventListener('keyup', filename_change);
-    fs.file_ext.addEventListener('change', filename_change);
-    filename_change();
+    fs.file_location.addEventListener('change', file_name_change);
+    fs.file_name.addEventListener('keyup', file_name_change);
+    fs.file_ext.addEventListener('change', file_name_change);
+    file_name_change();
   }
 }
 
@@ -27,32 +27,32 @@ function get_file_settings() {
     return false;
   }
 
-  var filename = document.getElementById("filename");
+  var file_name = document.getElementById("file_name");
   var file_ext = document.getElementById("file_ext");
 
   return {
     "file_location": file_location,
-    "filename": filename,
+    "file_name": file_name,
     "file_ext": file_ext
   }
 }
 
 
-function filename_change() {
+function file_name_change() {
   var fs = get_file_settings()
   if (fs !== false) {
     let flv = fs.file_location.value;
     let cds = current_datetime_string();
-    let fnv = fs.filename.value;
+    let fnv = fs.file_name.value;
     if (fnv.trim() == "") {
       fnv = "{file name}"
     }
     let fev = fs.file_ext.value;
 
-    var new_filename_display = flv + "/" + cds + "_" + fnv.trim() + "." + fev;
+    var new_file_name_display = flv + "/" + cds + "_" + fnv.trim() + "." + fev;
 
     var dfp = document.getElementById("dynamic_file_path");
-    dfp.innerText = new_filename_display;
+    dfp.innerText = new_file_name_display;
   }
 }
 

--- a/main.py
+++ b/main.py
@@ -18,8 +18,8 @@ from flask_helpers import (
     admin_interface,
     has_upload_rights,
     login_required,
-    upload_rights_required,
     render_template_custom,
+    upload_rights_required,
 )
 from logger import LOG
 
@@ -296,9 +296,7 @@ def upload():
     file_path_to_upload = ""
     presigned_object = ""
 
-    file_extensions = {
-        "csv": {"ext": "csv", "display": "CSV"}
-    }
+    file_extensions = {"csv": {"ext": "csv", "display": "CSV"}}
 
     upload_redirects = {
         "upload": "/upload?js_disabled=True",
@@ -320,14 +318,16 @@ def upload():
             preupload = False
 
             validated_form = upload_form_validate(
-                form_fields,
-                user_upload_paths,
-                file_extensions
+                form_fields, user_upload_paths, file_extensions
             )
 
             if validated_form["valid"]:
-                file_path_to_upload = generate_upload_file_path(validated_form["fields"])
-                app.logger.debug({"route": "upload", "file_path_to_upload": file_path_to_upload})
+                file_path_to_upload = generate_upload_file_path(
+                    validated_form["fields"]
+                )
+                app.logger.debug(
+                    {"route": "upload", "file_path_to_upload": file_path_to_upload}
+                )
                 # generate a S3 presigned_object PutObjct based
                 # on s3 key in file_path_to_upload
                 presigned_object = create_presigned_post(file_path_to_upload)
@@ -355,10 +355,7 @@ def generate_upload_file_path(form_fields):
     """
     now = datetime.now().strftime("%Y%m%d-%H%M%S")
     file_path_to_upload = "{}/{}_{}.{}".format(
-        form_fields["file_location"],
-        now,
-        form_fields["file_name"],
-        form_fields["ext"]
+        form_fields["file_location"], now, form_fields["file_name"], form_fields["ext"]
     )
     return file_path_to_upload
 
@@ -370,10 +367,7 @@ def upload_form_validate(form_fields, valid_paths, valid_extensions):
     file extensions approved for upload
     """
 
-    status = {
-        "valid": True,
-        "fields": {}
-    }
+    status = {"valid": True, "fields": {}}
     if "file_location" in form_fields:
         file_location = form_fields["file_location"]
         field_valid = file_location in valid_paths
@@ -381,7 +375,6 @@ def upload_form_validate(form_fields, valid_paths, valid_extensions):
             status["fields"]["file_location"] = file_location
         else:
             status["valid"] = False
-
 
     if "filename" in form_fields:
         file_name = secure_filename(form_fields["filename"])

--- a/main.py
+++ b/main.py
@@ -298,21 +298,11 @@ def upload():
 
     file_extensions = {"csv": {"ext": "csv", "display": "CSV"}}
 
-    upload_redirects = {
-        "upload": "/upload?js_disabled=True",
-        "cancel-upload": "/upload",
-        "cancel-preupload": "/",
-    }
-
     if request.method == "POST":
         form_fields = request.form
         task = form_fields.get("task", None)
 
         app.logger.debug({"form_fields": form_fields})
-
-        if task in upload_redirects.keys():
-            redirect_to = upload_redirects["task"]
-            return redirect(redirect_to)
 
         if task == "preupload":
             preupload = False

--- a/main.py
+++ b/main.py
@@ -537,7 +537,9 @@ def get_files(bucket_name: str, user_session: dict):
 
     resp = []
     for file_key in file_keys:
-        print("User {}: file_key: {}".format(user_session["user"], file_key["key"]))
+        app.logger.info(
+            "User {}: file_key: {}".format(user_session["user"], file_key["key"])
+        )
 
         url_string = f"/download/{file_key['key']}"
         resp.append(

--- a/main.py
+++ b/main.py
@@ -355,7 +355,10 @@ def generate_upload_file_path(form_fields):
     """
     now = datetime.now().strftime("%Y%m%d-%H%M%S")
     file_path_to_upload = "{}/{}_{}.{}".format(
-        form_fields["file_location"], now, form_fields["file_name"], form_fields["ext"]
+        form_fields["file_location"],
+        now,
+        form_fields["file_name"],
+        form_fields["file_ext"],
     )
     return file_path_to_upload
 
@@ -376,8 +379,8 @@ def upload_form_validate(form_fields, valid_paths, valid_extensions):
         else:
             status["valid"] = False
 
-    if "filename" in form_fields:
-        file_name = secure_filename(form_fields["filename"])
+    if "file_name" in form_fields:
+        file_name = secure_filename(form_fields["file_name"])
         app.logger.debug({"route": "upload", "file_name": file_name})
         status["fields"]["file_name"] = file_name
 
@@ -385,8 +388,8 @@ def upload_form_validate(form_fields, valid_paths, valid_extensions):
         ext = form_fields["file_ext"]
         field_valid = form_fields["file_ext"] in valid_extensions.keys()
         if field_valid:
-            status["fields"]["ext"] = ext
-            app.logger.debug({"route": "upload", "ext": ext})
+            status["fields"]["file_ext"] = ext
+            app.logger.debug({"route": "upload", "file_ext": ext})
         else:
             status["valid"] = False
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from flask_helpers import (
     admin_interface,
     has_upload_rights,
     login_required,
+    upload_rights_required,
     render_template_custom,
 )
 from logger import LOG
@@ -288,92 +289,115 @@ def download(path):
 
 @app.route("/upload", methods=["POST", "GET"])
 @login_required
+@upload_rights_required
 def upload():
-    if has_upload_rights():  # in group
-        ucps = user_custom_paths(is_upload=True, session=session)
-        preupload = True
-        file_extensions = [{"ext": "csv", "display": "CSV"}]
-        filepathtoupload = ""
-        presigned_object = ""
+    user_upload_paths = user_custom_paths(is_upload=True, session=session)
+    preupload = True
+    file_path_to_upload = ""
+    presigned_object = ""
 
-        if request.method == "POST":
-            args = request.form
-            if len(args) != 0:
+    file_extensions = {
+        "csv": {"ext": "csv", "display": "CSV"}
+    }
 
-                if "task" in args:
-                    print("task", args["task"])
-                    print("args", args)
+    upload_redirects = {
+        "upload": "/upload?js_disabled=True",
+        "cancel-upload": "/upload",
+        "cancel-preupload": "/",
+    }
 
-                    if args["task"] == "upload":
-                        # handled in javascript
-                        # return a redirect here if JS is disabled
-                        return redirect("/upload?js_disabled=True")
+    if request.method == "POST":
+        form_fields = request.form
+        task = form_fields.get("task", None)
 
-                    if args["task"] == "cancel-upload":
-                        return redirect("/upload")
+        app.logger.debug({"form_fields": form_fields})
 
-                    if args["task"] == "cancel-preupload":
-                        return redirect("/")
+        if task in upload_redirects.keys():
+            redirect_to = upload_redirects["task"]
+            return redirect(redirect_to)
 
-                    if args["task"] == "preupload":
-                        preupload = False
-                        complete = 0
-                        file_location = ""
-                        file_name = ""
-                        ext = ""
+        if task == "preupload":
+            preupload = False
 
-                        if "file_location" in args:
-                            arg_fl = args["file_location"]
-                            for fl in ucps:
-                                if fl["key"] == arg_fl:
-                                    file_location = fl["path"]
-                                    print("file_location", file_location)
-                                    complete += 1
-                                    break
+            validated_form = upload_form_validate(
+                form_fields,
+                user_upload_paths,
+                file_extensions
+            )
 
-                        if "filename" in args:
-                            arg_fn = args["filename"]
-                            file_name = secure_filename(arg_fn)
-                            print("file_name", file_name)
-                            complete += 1
+            if validated_form["valid"]:
+                file_path_to_upload = generate_upload_file_path(validated_form["fields"])
+                app.logger.debug({"route": "upload", "file_path_to_upload": file_path_to_upload})
+                # generate a S3 presigned_object PutObjct based
+                # on s3 key in file_path_to_upload
+                presigned_object = create_presigned_post(file_path_to_upload)
+                if presigned_object is None:
+                    return redirect("/upload?error=True")
+            else:
+                return redirect("/upload?error=True")
 
-                        if "file_ext" in args:
-                            arg_ext = args["file_ext"]
-                            for fe in file_extensions:
-                                if fe["ext"] == arg_ext:
-                                    ext = fe["ext"]
-                                    complete += 1
-                                    print("ext", ext)
-                                    break
+    return render_template_custom(
+        app,
+        "upload.html",
+        user=session["user"],
+        email=session["email"],
+        presigned_object=presigned_object,
+        preupload=preupload,
+        filepathtoupload=file_path_to_upload,
+        file_extensions=list(file_extensions.values()) if preupload else {},
+        upload_keys=user_upload_paths if preupload else [],
+    )
 
-                        if complete == 3:
-                            filedatetime = datetime.now().strftime("%Y%m%d-%H%M%S")
-                            filepathtoupload = "{}/{}_{}.{}".format(
-                                file_location, filedatetime, file_name, ext
-                            )
-                            print("filepathtoupload", filepathtoupload)
-                            # generate a S3 presigned_object PutObjct based
-                            # on filepathtoupload
-                            cpp = create_presigned_post(filepathtoupload)
-                            if cpp is None:
-                                return redirect("/upload?error=True")
-                            presigned_object = cpp
-                        else:
-                            return redirect("/upload?error=True")
 
-        return render_template_custom(
-            app,
-            "upload.html",
-            user=session["user"],
-            email=session["email"],
-            presigned_object=presigned_object,
-            preupload=preupload,
-            filepathtoupload=filepathtoupload,
-            file_extensions=file_extensions if preupload else [],
-            upload_keys=[u["key"] for u in ucps] if preupload else [],
-        )
-    else:
-        return redirect("/")
+def generate_upload_file_path(form_fields):
+    """
+    Use validated form fields to create the key for S3
+    """
+    now = datetime.now().strftime("%Y%m%d-%H%M%S")
+    file_path_to_upload = "{}/{}_{}.{}".format(
+        form_fields["file_location"],
+        now,
+        form_fields["file_name"],
+        form_fields["ext"]
+    )
+    return file_path_to_upload
+
+
+def upload_form_validate(form_fields, valid_paths, valid_extensions):
+    """
+    Pass in the submitted form data along with
+    paths granted to the user and
+    file extensions approved for upload
+    """
+
+    status = {
+        "valid": True,
+        "fields": {}
+    }
+    if "file_location" in form_fields:
+        file_location = form_fields["file_location"]
+        field_valid = file_location in valid_paths
+        if field_valid:
+            status["fields"]["file_location"] = file_location
+        else:
+            status["valid"] = False
+
+
+    if "filename" in form_fields:
+        file_name = secure_filename(form_fields["filename"])
+        app.logger.debug({"route": "upload", "file_name": file_name})
+        status["fields"]["file_name"] = file_name
+
+    if "file_ext" in form_fields:
+        ext = form_fields["file_ext"]
+        field_valid = form_fields["file_ext"] in valid_extensions.keys()
+        if field_valid:
+            status["fields"]["ext"] = ext
+            app.logger.debug({"route": "upload", "ext": ext})
+        else:
+            status["valid"] = False
+
+    return status
 
 
 def key_has_granted_prefix(key, prefixes):
@@ -537,39 +561,26 @@ def return_attribute(session: dict, get_attribute: str) -> str:
 
 
 def user_custom_paths(session, is_upload=False):
-    paths = []
+    # paths = []
 
     app_download_path = os.getenv("BUCKET_MAIN_PREFIX", "web-app-prod-data")
     app_upload_path = os.getenv("BUCKET_UPLOAD_PREFIX", "web-app-upload")
 
-    user_key_prefixes = return_attribute(session, "custom:paths")
-    for key_prefix in user_key_prefixes.split(";"):
-        if key_prefix != "" and "/" in key_prefix:
-            if not is_upload and not key_prefix.startswith(app_download_path):
-                continue
+    user_paths_attribute = return_attribute(session, "custom:paths")
+    user_paths = user_paths_attribute.split(";")
 
-            skp = key_prefix.split("/", 1)
-            if is_upload:
-                key = skp[1]
-                path = "{}/{}".format(app_upload_path, skp[1])
-            else:
-                key = key_prefix
-                path = key_prefix
-            if key != "" and path != "":
-                paths.append({"key": key, "path": path})
+    user_paths = [
+        path.replace(app_download_path, app_upload_path) if is_upload else path
+        for path in user_paths
+        if path.startswith(app_download_path)
+    ]
 
-    return paths
+    return user_paths
 
 
 def load_user_lookup(session):
-    paths = []
-
-    ucps = user_custom_paths(session, is_upload=False)
-    for ucp in ucps:
-        paths.append(ucp["path"])
-        app.logger.info("User: {} prefix: {}".format(session["user"], ucp["path"]))
-
-    return paths
+    user_paths = user_custom_paths(session, is_upload=False)
+    return user_paths
 
 
 @app.template_filter("s3_remove_root_path")

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ env =
     AWS_DEFAULT_REGION=eu-west-1
     CLIENT_ID=123456
     CLIENT_SECRET=987654  ; pragma: allowlist secret
+    BUCKET_NAME=test_bucket

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -51,7 +51,7 @@
 
     <p>You'll be asked to select a file when you continue</p>
     <button id="preuploadbut" name="task" value="preupload" class="govuk-button govuk-!-margin-right-1" data-module="govuk-button" type="submit">Continue</button>
-    <button id="preupload_cancel" name="task" value="cancel-preupload" class="govuk-button govuk-button--secondary" data-module="govuk-button" type="submit">Cancel</button>
+    <a href="/" id="preupload_cancel" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</a>
   </form>
 
   {% else %}
@@ -79,7 +79,7 @@
       <button id="upload_submit" class="govuk-button govuk-!-margin-right-1" data-module="govuk-button" type="submit">Start upload</button>
     </form>
 
-    <a href="/upload"><button class="govuk-button govuk-button--secondary" data-module="govuk-button" type="button">Cancel</button></a>
+    <a href="/upload" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</a>
   </div>
   <div id="uploading_panel" class="hidden">
     <div id="uploading_spinner" class="govuk-!-margin-bottom-7 loading-spinner"></div>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -22,10 +22,10 @@
     </div>
 
     <div class="govuk-form-group">
-      <label class="govuk-label" for="filename">
+      <label class="govuk-label" for="file_name">
         <b>File name (excluding extension):</b>
       </label>
-      <input class="govuk-input" id="filename" name="filename" type="text">
+      <input class="govuk-input" id="file_name" name="file_name" type="text">
     </div>
 
     <div class="govuk-form-group">
@@ -101,5 +101,5 @@
 
 {% endblock %}
 {% block scriptblock %}
-  <script src="/js/s3upload.js?update=20200408-1234"></script>
+  <script src="/js/s3upload.js?update=20200408-1619"></script>
 {% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -12,11 +12,11 @@
       </label>
 
       {% if upload_keys|length == 1 %}
-        <p>{{ upload_keys[0] }}<p>
+        <p>{{ upload_keys[0] | s3_remove_root_path }}<p>
       {% endif %}
       <select class="govuk-select {{ 'hidden' if upload_keys|length == 1 else '' }}" id="file_location" name="file_location">
         {% for ukey in upload_keys %}
-        <option value="{{ ukey }}" {{ "selected='selected'" if upload_keys|length == 1 else "" }}>{{ ukey }}</option>
+        <option value="{{ ukey }}" {{ "selected='selected'" if upload_keys|length == 1 else "" }}>{{ ukey | s3_remove_root_path }}</option>
         {% endfor %}
       </select>
     </div>
@@ -33,11 +33,11 @@
         <b>File extension:</b>
       </label>
       {% if file_extensions|length == 1 %}
-        <p>{{ file_extensions[0]['display'] }}<p>
+      <p>{{ file_extensions[0]['display'] }}<p>
       {% endif %}
       <select class="govuk-select {{ 'hidden' if file_extensions|length == 1 else '' }}" id="file_ext" name="file_ext">
         {% for ext in file_extensions %}
-        <option value="{{ ext['ext'] }}" {{ "selected='selected'" if file_extensions|length == 1 else "" }}>{{ ext['display'] }}</option>
+        <option value="{{ ext['ext'] }}" {{ "selected" if file_extensions|length == 1 else "" }}>{{ ext['display'] }}</option>
         {% endfor %}
       </select>
     </div>
@@ -101,5 +101,5 @@
 
 {% endblock %}
 {% block scriptblock %}
-  <script src="/js/s3upload.js?update=20200407-2050"></script>
+  <script src="/js/s3upload.js?update=20200408-1234"></script>
 {% endblock %}

--- a/tests/test_flask_helpers.py
+++ b/tests/test_flask_helpers.py
@@ -1,6 +1,8 @@
+import os
+
 import pytest
 
-from flask_helpers import has_upload_rights
+from flask_helpers import has_upload_rights, is_admin_interface, is_development
 from main import app
 
 
@@ -13,3 +15,21 @@ def test_route_index_logged_in(test_client, test_session):
     with app.test_request_context("/"):
         is_upload = has_upload_rights()
         assert not is_upload
+
+
+def test_is_admin_interface():
+    os.environ["ADMIN"] = "true"
+    assert is_admin_interface()
+    os.environ["ADMIN"] = "false"
+    assert not is_admin_interface()
+    del os.environ["ADMIN"]
+    assert not is_admin_interface()
+
+
+def test_is_development():
+    os.environ["FLASK_ENV"] = "development"
+    assert is_development()
+    os.environ["FLASK_ENV"] = "production"
+    assert not is_development()
+    del os.environ["FLASK_ENV"]
+    assert not is_development()

--- a/tests/test_flask_helpers.py
+++ b/tests/test_flask_helpers.py
@@ -1,0 +1,15 @@
+import pytest
+
+from flask_helpers import has_upload_rights
+from main import app
+
+
+@pytest.mark.usefixtures("test_client")
+@pytest.mark.usefixtures("test_session")
+def test_route_index_logged_in(test_client, test_session):
+    with test_client.session_transaction() as client_session:
+        client_session.update(test_session)
+        app.logger.debug(test_session)
+    with app.test_request_context("/"):
+        is_upload = has_upload_rights()
+        assert not is_upload

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,7 @@ from main import (
     key_has_granted_prefix,
     load_user_lookup,
     return_attribute,
+    user_custom_paths,
 )
 
 
@@ -260,6 +261,14 @@ def test_create_presigned_url(test_session):
         url = create_presigned_url(bucket, key, expiration=600)
         assert ".co/test_bucket/test_key" in url
         stubber.deactivate()
+
+
+@pytest.mark.usefixtures("test_session")
+def test_user_custom_paths(test_session):
+    download_paths = user_custom_paths(test_session, is_upload=False)
+    print(download_paths)
+    upload_paths = user_custom_paths(test_session, is_upload=True)
+    print(upload_paths)
 
 
 def test_key_has_granted_prefix():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,10 +9,12 @@ import stubs
 from main import (
     app,
     create_presigned_url,
+    generate_upload_file_path,
     get_files,
     key_has_granted_prefix,
     load_user_lookup,
     return_attribute,
+    upload_form_validate,
     user_custom_paths,
 )
 
@@ -339,6 +341,25 @@ def test_user_custom_paths(test_session):
     assert "web-app-prod-data/local_authority/haringey" in download_paths
     upload_paths = user_custom_paths(test_session, is_upload=True)
     assert "web-app-upload/local_authority/barnet" in upload_paths
+
+
+@pytest.mark.usefixtures("test_upload_session")
+@pytest.mark.usefixtures("upload_form_fields")
+@pytest.mark.usefixtures("valid_extensions")
+def test_upload_form_validate(test_session, upload_form_fields, valid_extensions):
+    upload_paths = user_custom_paths(test_session, is_upload=True)
+    validation_status = upload_form_validate(
+        upload_form_fields, upload_paths, valid_extensions
+    )
+    assert validation_status["valid"]
+
+
+@pytest.mark.usefixtures("upload_form_fields")
+def test_generate_upload_file_path(upload_form_fields):
+    file_path = generate_upload_file_path(upload_form_fields)
+    assert file_path.startswith(upload_form_fields["file_location"])
+    assert upload_form_fields["file_name"] in file_path
+    assert file_path.endswith(f".{upload_form_fields['file_ext']}")
 
 
 def test_key_has_granted_prefix():


### PR DESCRIPTION
Break up upload route into separate functions to enable testing and decrease indentation. 
Add upload_rights_required decorator for /upload route.
Add unit tests for component functions. 
Test route loading. 
Simplify form validation and make naming consistent (file_name and file_ext).
Simplify user_custom_paths and user template filter to remove root path in HTML rendering.
Remove redirect tasks in upload route: 
2 x unused.
1 x replaced with a link with href.