### PR TITLE
Admin unit tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-04-09T10:09:33Z",
+  "generated_at": "2020-04-14T16:29:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -60,7 +60,7 @@
         "hashed_secret": "dea742e166979027ae70b28e0a9006fb1010e760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 179,
         "type": "Secret Keyword"
       }
     ]

--- a/admin.py
+++ b/admin.py
@@ -110,18 +110,7 @@ def admin_confirm_user(app):
     elif "task" in args:
         task = args["task"]
 
-    task_redirects = {
-        "cancel-existing": "/admin/user",
-        "cancel-new": "/admin",
-        "edit-exiting": "/admin/user/edit",
-        "edit-new": "/admin/user/edit"
-    }
-
     app.logger.debug("admin_confirm_user:task:", task)
-
-    if task in ["edit-exiting", "edit-new"]:
-        app.logger.debug("admin_confirm_user: redirecting back to edit")
-        return redirect("/admin/user/edit")
 
     user = {}
     new_user = False

--- a/admin.py
+++ b/admin.py
@@ -133,35 +133,21 @@ def admin_confirm_user(app):
         if "self" == args["frompage"]:
 
             if task == "confirm-new":
-                email = admin_user_object["email"]
-                create_res = cognito.create_user(
-                    name=admin_user_object["name"],
-                    email_address=email,
-                    phone_number=admin_user_object["phone_number"],
-                    attr_paths=admin_user_object["custom:paths"],
-                    is_la=admin_user_object["custom:is_la"],
-                    group_name=admin_user_object["group"]["value"],
-                )
+                create_res = cognito.create_user(admin_user_object)
 
                 clear_session(app)
 
                 if create_res:
                     return redirect(
-                        "/admin/user?done=created&email={}".format(quote(email))
+                        "/admin/user?done=created&email={}".format(quote(admin_user_object["email"]))
                     )
                 else:
                     return redirect("/admin/user/error")
 
             if task == "confirm-existing":
                 email = admin_user_object["email"]
-                update_res = cognito.update_user_attributes(
-                    email_address=email,
-                    new_name=admin_user_object["name"],
-                    new_phone_number=admin_user_object["phone_number"],
-                    new_paths=admin_user_object["custom:paths"].split(";"),
-                    new_is_la=admin_user_object["custom:is_la"],
-                    new_group_name=admin_user_object["group"]["value"],
-                )
+
+                update_res = cognito.update_user_attributes(admin_user_object)
 
                 clear_session(app)
 

--- a/admin.py
+++ b/admin.py
@@ -245,34 +245,6 @@ def admin_edit_user(app):
     if admin_user_email == "" or cognito.get_user_details(admin_user_email) == {}:
         new_user = True
 
-    if task == "enable":
-        return render_template_custom(
-            app,
-            "admin/confirm-enable.html",
-            email=quote(admin_user_object["email"]),
-            user_email=admin_user_object["email"],
-        )
-    if task == "do-enable-user":
-        email = admin_user_object["email"]
-        clear_session(app)
-        cognito.enable_user(email, True)
-        session["admin_user_email"] = email
-        return redirect("/admin/user?done=enabled")
-
-    if task == "disable":
-        return render_template_custom(
-            app,
-            "admin/confirm-disable.html",
-            email=quote(admin_user_object["email"]),
-            user_email=admin_user_object["email"],
-        )
-    if task == "do-disable-user":
-        email = admin_user_object["email"]
-        clear_session(app)
-        cognito.disable_user(email, True)
-        session["admin_user_email"] = email
-        return redirect("/admin/user?done=disabled")
-
     if task == "delete":
         return render_template_custom(
             app,
@@ -333,6 +305,56 @@ def admin_reinvite_user(app):
     return render_template_custom(
         app,
         "admin/confirm-reinvite.html",
+        email=quote(admin_user_object["email"]),
+        user_email=admin_user_object["email"],
+    )
+
+
+def admin_enable_user(app):
+
+    args = request.values
+
+    task = ""
+    if "task" in args:
+        task = args["task"]
+
+    admin_user_object = session["admin_user_object"]
+
+    if task == "do-enable-user":
+        email = admin_user_object["email"]
+        clear_session(app)
+        cognito.enable_user(email, True)
+        session["admin_user_email"] = email
+        return redirect("/admin/user?done=enabled")
+
+    return render_template_custom(
+        app,
+        "admin/confirm-enable.html",
+        email=quote(admin_user_object["email"]),
+        user_email=admin_user_object["email"],
+    )
+
+
+def admin_disable_user(app):
+
+    args = request.values
+
+    task = ""
+    if "task" in args:
+        task = args["task"]
+
+    admin_user_object = session["admin_user_object"]
+
+    if task == "do-disable-user":
+        email = admin_user_object["email"]
+        clear_session(app)
+        cognito.disable_user(email, True)
+        session["admin_user_email"] = email
+        return redirect("/admin/user?done=disabled")
+    
+    return render_template_custom(
+        app,
+        "admin/confirm-disable.html",
         email=quote(admin_user_object["email"]),
         user_email=admin_user_object["email"],
     )

--- a/admin.py
+++ b/admin.py
@@ -150,9 +150,19 @@ def admin_confirm_user(app):
 
 
 def parse_edit_form_fields(
-    post_fields: list, admin_user_object: dict, app: Flask
+    post_fields: dict, admin_user_object: dict, app: Flask
 ) -> dict:
 
+    app.logger.debug(
+        {"action": "parse_edit_form_fields", "fields_type": str(type(post_fields))}
+    )
+    app.logger.debug(
+        {
+            "action": "parse_edit_form_fields",
+            "custom_paths": post_fields.getlist("custom_paths"),
+        }
+    )
+    app.logger.debug({"action": "parse_edit_form_fields", "post_fields": post_fields})
     sanitised_fields = {
         "custom_paths": [
             sanitise_string(input_path).replace("&amp;", "&")

--- a/admin.py
+++ b/admin.py
@@ -132,35 +132,27 @@ def admin_confirm_user(app):
     if "frompage" in args:
         if "self" == args["frompage"]:
 
+            state = ""
+
             if task == "confirm-new":
-                create_res = cognito.create_user(admin_user_object)
+                response = cognito.create_user(admin_user_object)
+                state = "created"
 
-                clear_session(app)
-
-                if create_res:
-                    return redirect(
-                        "/admin/user?done=created&email={}".format(quote(admin_user_object["email"]))
-                    )
-                else:
-                    return redirect("/admin/user/error")
-
-            if task == "confirm-existing":
-                email = admin_user_object["email"]
-
-                update_res = cognito.update_user_attributes(admin_user_object)
-
-                clear_session(app)
-
-                if update_res:
-                    return redirect(
-                        "/admin/user?done=updated&email={}".format(quote(email))
-                    )
-                else:
-                    return redirect("/admin/user/error")
-
+            elif task == "confirm-existing":
+                response = cognito.update_user_attributes(admin_user_object)
+                state = "updated"
             else:
                 session["admin_user_object"] = admin_user_object
                 return redirect("/admin/user/edit")
+
+            clear_session(app)
+
+            if response:
+                return redirect(
+                    "/admin/user?done={}&email={}".format(state, quote(admin_user_object["email"]))
+                )
+            else:
+                return redirect("/admin/user/error")
 
         return redirect("/admin/user/error")
 

--- a/admin.py
+++ b/admin.py
@@ -93,12 +93,20 @@ def admin_main(app):
 
 
 def admin_confirm_user(app):
+    """
+    Render the /admin/user/confirm flask route
 
-    # 
+    This route posts back to the same page and performs the 
+    user create/updates against cognito.
+    """
+
+    # Get the edited user content from the session 
+    # or initialise as an empty dictionary
     admin_user_object = session.get("admin_user_object", {})
     task = ""
     new_user = False
     
+    # Redirect to admin home if post data missing
     args = request.form
     if len(args) == 0:
         clear_session(app)
@@ -108,7 +116,7 @@ def admin_confirm_user(app):
 
     app.logger.debug({"action": "admin_confirm_user", "args:": args})
 
-    # Pre-populate the form from 
+    # Sanitise the email address if user edited
     if task in ["new", "continue-new"]:
         new_user = True
         if "email" in args:

--- a/admin.py
+++ b/admin.py
@@ -10,7 +10,6 @@ from cognito_groups import get_group_by_name, return_users_group, user_groups
 from flask_helpers import render_template_custom
 from logger import LOG
 
-
 local_valid_paths_var = []
 
 
@@ -203,10 +202,12 @@ def parse_edit_form_fields(
     return admin_user_object
 
 
-def requested_path_matches_user_type(is_local_authority, requested_path):
+def requested_path_matches_user_type(
+    is_local_authority: bool, requested_path: str
+) -> bool:
     is_path_valid = True
     if requested_path == "":
-        is_path_valid = False 
+        is_path_valid = False
     elif (not is_local_authority) and "local_authority" in requested_path:
         is_path_valid = False
     elif is_local_authority and ("local_authority" not in requested_path):
@@ -214,7 +215,7 @@ def requested_path_matches_user_type(is_local_authority, requested_path):
     return is_path_valid
 
 
-def remove_invalid_user_paths(user):
+def remove_invalid_user_paths(user: dict) -> dict:
     user_custom_paths = user["custom:paths"].split(";")
     is_local_authority_user = user["custom:is_la"] == "1"
     valid_user_paths = []
@@ -224,24 +225,24 @@ def remove_invalid_user_paths(user):
         )
         if is_path_valid:
             LOG.debug(
-                "path: %s is valid for %s", 
-                custom_path, 
-                "LA user" if is_local_authority_user else "non-LA user"
+                "path: %s is valid for %s",
+                custom_path,
+                "LA user" if is_local_authority_user else "non-LA user",
             )
             valid_user_paths.append(custom_path)
-        else: 
+        else:
             LOG.debug(
-                "path: %s is not valid for %s", 
+                "path: %s is not valid for %s",
                 custom_path,
-                "LA user" if is_local_authority_user else "non-LA user"
+                "LA user" if is_local_authority_user else "non-LA user",
             )
 
     user["custom:paths"] = ";".join(valid_user_paths)
-    
+
     return user
 
 
-def perform_cognito_task(task, admin_user_object):
+def perform_cognito_task(task: str, admin_user_object: dict) -> bool:
     is_task_complete = False
 
     if task == "confirm-new":
@@ -399,4 +400,4 @@ def admin_delete_user(app):
 
 
 def admin_user_not_found(app):
-    return "User not found"
+    return render_template_custom(app, "error.html", error="User not found")

--- a/admin.py
+++ b/admin.py
@@ -119,15 +119,6 @@ def admin_confirm_user(app):
 
     app.logger.debug("admin_confirm_user:task:", task)
 
-    if task == "cancel-existing":
-        app.logger.debug("admin_confirm_user: redirecting back to user")
-        return redirect("/admin/user")
-
-    if task == "cancel-new":
-        clear_session(app)
-        app.logger.debug("admin_confirm_user: redirecting back to admin")
-        return redirect("/admin")
-
     if task in ["edit-exiting", "edit-new"]:
         app.logger.debug("admin_confirm_user: redirecting back to edit")
         return redirect("/admin/user/edit")

--- a/admin.py
+++ b/admin.py
@@ -109,6 +109,13 @@ def admin_confirm_user(app):
     elif "task" in args:
         task = args["task"]
 
+    task_redirects = {
+        "cancel-existing": "/admin/user",
+        "cancel-new": "/admin",
+        "edit-exiting": "/admin/user/edit",
+        "edit-new": "/admin/user/edit"
+    }
+
     app.logger.debug("admin_confirm_user:task:", task)
 
     if task == "cancel-existing":
@@ -235,9 +242,6 @@ def admin_edit_user(app):
     task = ""
     if "task" in args:
         task = args["task"]
-
-    if task == "goto-view":
-        return redirect("/admin/user")
 
     if task == "cancel":
         clear_session(app)

--- a/admin.py
+++ b/admin.py
@@ -94,6 +94,7 @@ def admin_list_users(app):
 
 
 def admin_main(app):
+    clear_session(app)
     return render_template_custom(app, "admin/index.html")
 
 
@@ -242,10 +243,6 @@ def admin_edit_user(app):
     task = ""
     if "task" in args:
         task = args["task"]
-
-    if task == "cancel":
-        clear_session(app)
-        return redirect("/admin")
 
     if task == "new":
         clear_session(app)

--- a/admin.py
+++ b/admin.py
@@ -245,19 +245,6 @@ def admin_edit_user(app):
     if admin_user_email == "" or cognito.get_user_details(admin_user_email) == {}:
         new_user = True
 
-    if task == "delete":
-        return render_template_custom(
-            app,
-            "admin/confirm-delete.html",
-            email=quote(admin_user_object["email"]),
-            user_email=admin_user_object["email"],
-        )
-    if task == "do-delete-user":
-        email = admin_user_object["email"]
-        clear_session(app)
-        cognito.delete_user(email, True)
-        return redirect("/admin?done=deleted")
-
     is_la = False
     is_other = False
 
@@ -359,6 +346,30 @@ def admin_disable_user(app):
         user_email=admin_user_object["email"],
     )
 
+
+def admin_delete_user(app):
+
+    args = request.values
+
+    task = ""
+    if "task" in args:
+        task = args["task"]
+
+    admin_user_object = session["admin_user_object"]
+
+    if task == "do-delete-user":
+        email = admin_user_object["email"]
+        clear_session(app)
+        cognito.delete_user(email, True)
+        return redirect("/admin?done=deleted")
+
+    return render_template_custom(
+        app,
+        "admin/confirm-delete.html",
+        email=quote(admin_user_object["email"]),
+        user_email=admin_user_object["email"],
+    )
+    
 
 def admin_user_not_found(app):
     return "User not found"

--- a/admin.py
+++ b/admin.py
@@ -245,20 +245,6 @@ def admin_edit_user(app):
     if admin_user_email == "" or cognito.get_user_details(admin_user_email) == {}:
         new_user = True
 
-    if task == "reinvite":
-        return render_template_custom(
-            app,
-            "admin/confirm-reinvite.html",
-            email=quote(admin_user_object["email"]),
-            user_email=admin_user_object["email"],
-        )
-    if task == "do-reinvite-user":
-        email = admin_user_object["email"]
-        cognito.reinvite_user(email, True)
-        clear_session(app)
-        session["admin_user_email"] = email
-        return redirect("/admin/user?done=reinvited")
-
     if task == "enable":
         return render_template_custom(
             app,
@@ -325,6 +311,30 @@ def admin_edit_user(app):
         is_other=is_other,
         allowed_domains=(cognito.allowed_domains() if new_user else []),
         available_groups=user_groups(),
+    )
+
+
+def admin_reinvite_user(app):
+    args = request.values
+
+    task = ""
+    if "task" in args:
+        task = args["task"]
+
+    admin_user_object = session["admin_user_object"]
+
+    if task == "do-reinvite-user":
+        email = admin_user_object["email"]
+        cognito.reinvite_user(email, True)
+        clear_session(app)
+        session["admin_user_email"] = email
+        return redirect("/admin/user?done=reinvited")
+
+    return render_template_custom(
+        app,
+        "admin/confirm-reinvite.html",
+        email=quote(admin_user_object["email"]),
+        user_email=admin_user_object["email"],
     )
 
 

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -1,4 +1,5 @@
 import requests
+
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -1,5 +1,4 @@
 import requests
-
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 

--- a/cognito.py
+++ b/cognito.py
@@ -189,7 +189,7 @@ def get_user_details(email_address):
             )
             return normalise_user(user)
     except ClientError as error:
-        LOG.debug({"error":error})
+        LOG.debug({"error": error})
     return {}
 
 
@@ -389,9 +389,7 @@ def add_user_to_group(username, group_name=None):
     return False
 
 
-def create_user(
-    user
-):
+def create_user(user):
     name = user["name"]
     email_address = user["email"]
     phone_number = user["phone_number"]

--- a/cognito.py
+++ b/cognito.py
@@ -397,8 +397,15 @@ def add_user_to_group(username, group_name=None):
 
 
 def create_user(
-    name, email_address, phone_number, attr_paths, is_la="0", group_name=None
+    user
 ):
+    name = user["name"]
+    email_address = user["email"]
+    phone_number = user["phone_number"]
+    attr_paths = user["custom:paths"]
+    is_la = user["custom:is_la"]
+    group_name = user["group"]["value"]
+
     client = get_boto3_client()
     email_address = sanitise_email(email_address)
     if email_address == "":
@@ -514,14 +521,15 @@ def delete_user(email_address, confirm=False):
     return False
 
 
-def update_user_attributes(
-    email_address,
-    new_name=None,
-    new_phone_number=None,
-    new_is_la=None,
-    new_paths=None,
-    new_group_name=None,
-):
+def update_user_attributes(user):
+
+    email_address = user["email"]
+    new_name = user["name"]
+    new_phone_number = user["phone_number"]
+    new_paths = user["custom:paths"]
+    new_is_la = user["custom:is_la"]
+    new_group_name = None if "group" not in user else user["group"]["value"]
+
     client = get_boto3_client()
     if (
         new_name is None
@@ -575,15 +583,14 @@ def update_user_attributes(
                 return False
 
         if new_paths is not None:
-            if isinstance(new_paths, list):
-                path_scsl = str.join(";", new_paths)
+            if isinstance(new_paths, str):
 
-                if not return_false_if_paths_bad(is_la_value, path_scsl):
+                if not return_false_if_paths_bad(is_la_value, new_paths):
                     return False
 
-                attrs.append({"Name": "custom:paths", "Value": path_scsl})
+                attrs.append({"Name": "custom:paths", "Value": new_paths})
             else:
-                LOG.error("ERR: %s: new_paths is not list", "user-admin")
+                LOG.error("ERR: %s: new_paths is not a string", "user-admin")
                 return False
 
         if new_group_name is not None:

--- a/cognito.py
+++ b/cognito.py
@@ -181,12 +181,15 @@ def san_row(row):
 
 def get_user_details(email_address):
     client = get_boto3_client()
-    san_email_address = sanitise_email(email_address)
-    if san_email_address != "":
-        user = client.admin_get_user(
-            UserPoolId=get_env_pool_id(), Username=san_email_address
-        )
-        return normalise_user(user)
+    try:
+        san_email_address = sanitise_email(email_address)
+        if san_email_address != "":
+            user = client.admin_get_user(
+                UserPoolId=get_env_pool_id(), Username=san_email_address
+            )
+            return normalise_user(user)
+    except ClientError as error:
+        LOG.debug({"error":error})
     return {}
 
 

--- a/cognito.py
+++ b/cognito.py
@@ -208,7 +208,7 @@ def users_group(username):
     # return return_users_group(groups)
     # Currently you can attach a list of users in cognito
     # but we're currently only interested in the first group
-    group_name = groups[0] if len(groups) > 0 else None
+    group_name = None if len(groups) == 0 else groups[0]
     return get_group_by_name(group_name)
 
 

--- a/cognito.py
+++ b/cognito.py
@@ -5,11 +5,9 @@
 # import csv
 import os
 import re
-import time
 
 import boto3
 from botocore.exceptions import ClientError
-from flask import session
 
 from cognito_groups import get_group_by_name, get_group_map, user_groups
 from logger import LOG
@@ -390,11 +388,11 @@ def add_user_to_group(username, group_name=None):
 
 def create_user(user):
     """
-    Create and set properties of cognito user 
+    Create and set properties of cognito user
 
-    Create user in cognito user pool 
-    If successful then: 
-    - Set MFA preference to SMS 
+    Create user in cognito user pool
+    If successful then:
+    - Set MFA preference to SMS
     - Set MFA SMS phone number
     - Add user to the requested cognito group
     """
@@ -447,7 +445,7 @@ def create_user(user):
             statuses["create_user"] = res
 
     if statuses.get("create_user", False):
-        
+
         try:
             client.admin_set_user_mfa_preference(
                 SMSMfaSettings={"Enabled": True, "PreferredMfa": True},

--- a/cognito.py
+++ b/cognito.py
@@ -326,14 +326,7 @@ def reinvite_user(email_address, confirm=False):
             del_res = delete_user(email_address, confirm)
             LOG.debug({"action": "delete-user", "response": del_res})
             if del_res:
-                cre_res = create_user(
-                    name=user["name"],
-                    email_address=user["email"],
-                    phone_number=user["phone_number"],
-                    attr_paths=user["custom:paths"],
-                    is_la=user["custom:is_la"],
-                    group_name=user["group"]["value"],
-                )
+                cre_res = create_user(user)
                 LOG.debug({"action": "create-user", "response": "cre_res"})
                 return cre_res
     return False

--- a/conftest.py
+++ b/conftest.py
@@ -124,3 +124,40 @@ def upload_form_fields():
 @pytest.fixture()
 def valid_extensions():
     return {"csv": {"ext": "csv", "display": "CSV"}}
+
+
+@pytest.fixture()
+def admin_user():
+    return {
+        "name": "Justin Casey",
+        "email": "justin.casey@communities.gov.uk",
+        "phone_number": "+447123456789",
+        "group": {
+            "preference": 10,
+            "value": "standard-download",
+            "display": "Standard download user",
+        },
+        "custom:is_la": "1",
+        "custom:paths": ";".join(
+            [
+                "web-app-prod-data/local_authority/barking",
+                "web-app-prod-data/local_authority/haringey",
+            ]
+        ),
+    }
+
+
+@pytest.fixture()
+def user_confirm_form():
+    form = {
+        "full-name": "Justin Casey",
+        "email": "justin.casey@communities.gov.uk",
+        "telephone-number": "07123456789",
+        "account": "standard-upload",
+        "is-la-radio": "yes",
+        "custom_paths": [
+            "web-app-prod-data/local_authority/barnet",
+            "web-app-prod-data/local_authority/hackney",
+        ],
+    }
+    return form

--- a/main.py
+++ b/main.py
@@ -455,10 +455,22 @@ def admin_edit_user():
     return admin.admin_edit_user(app)
 
 
-@app.route("/admin/user/reinvite", methods=["POST", "GET"])
+@app.route("/admin/user/reinvite", methods=["POST"])
 @admin_interface
 def admin_reinvite_user():
     return admin.admin_reinvite_user(app)
+
+
+@app.route("/admin/user/enable", methods=["POST"])
+@admin_interface
+def admin_enable_user():
+    return admin.admin_enable_user(app)
+
+
+@app.route("/admin/user/disable", methods=["POST"])
+@admin_interface
+def admin_disable_user():
+    return admin.admin_disable_user(app)
 
 
 @app.route("/admin/user/error")

--- a/main.py
+++ b/main.py
@@ -473,6 +473,12 @@ def admin_disable_user():
     return admin.admin_disable_user(app)
 
 
+@app.route("/admin/user/delete", methods=["POST"])
+@admin_interface
+def admin_delete_user():
+    return admin.admin_delete_user(app)
+
+
 @app.route("/admin/user/error")
 @admin_interface
 def admin_user_error():

--- a/main.py
+++ b/main.py
@@ -455,6 +455,12 @@ def admin_edit_user():
     return admin.admin_edit_user(app)
 
 
+@app.route("/admin/user/reinvite", methods=["POST", "GET"])
+@admin_interface
+def admin_reinvite_user():
+    return admin.admin_reinvite_user(app)
+
+
 @app.route("/admin/user/error")
 @admin_interface
 def admin_user_error():

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ env =
     CLIENT_ID=123456
     CLIENT_SECRET=987654  ; pragma: allowlist secret
     BUCKET_NAME=test_bucket
+    ADMIN=true

--- a/templates/admin/confirm-delete.html
+++ b/templates/admin/confirm-delete.html
@@ -8,7 +8,7 @@
 </div>
 
 <form method="post">
-  <button name="task" value="goto-view" type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</button>
+  <a name="task" href="/admin/user" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</a>
   <button name="task" value="do-delete-user" type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button">Delete</button>
 </form>
 

--- a/templates/admin/confirm-disable.html
+++ b/templates/admin/confirm-disable.html
@@ -8,7 +8,7 @@
 </div>
 
 <form method="post">
-  <button name="task" value="goto-view" type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</button>
+  <a name="task" href="/admin/user" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</a>
   <button name="task" value="do-disable-user" type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button">Disable</button>
 </form>
 

--- a/templates/admin/confirm-enable.html
+++ b/templates/admin/confirm-enable.html
@@ -8,7 +8,7 @@
 </div>
 
 <form method="post">
-  <button name="task" value="goto-view" type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</button>
+  <a name="task" href="/admin/user" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</a>
   <button name="task" value="do-enable-user" type="submit" class="govuk-button" data-module="govuk-button">Enable</button>
 </form>
 

--- a/templates/admin/confirm-reinvite.html
+++ b/templates/admin/confirm-reinvite.html
@@ -9,7 +9,6 @@
 </div>
 
 <form method="post">
-  <!--button name="task" value="goto-view" type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</button-->
   <a name="task" href="/admin/user" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</a>
   <button name="task" value="do-reinvite-user" type="submit" class="govuk-button" data-module="govuk-button">Reinvite</button>
 </form>

--- a/templates/admin/confirm-reinvite.html
+++ b/templates/admin/confirm-reinvite.html
@@ -9,7 +9,8 @@
 </div>
 
 <form method="post">
-  <button name="task" value="goto-view" type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</button>
+  <!--button name="task" value="goto-view" type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</button-->
+  <a name="task" href="/admin/user" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</a>
   <button name="task" value="do-reinvite-user" type="submit" class="govuk-button" data-module="govuk-button">Reinvite</button>
 </form>
 

--- a/templates/admin/confirm-user.html
+++ b/templates/admin/confirm-user.html
@@ -57,7 +57,7 @@
 
 <form method="post">
   <input type="hidden" name="frompage" value="self">
-  <button name="task" value="{{ 'edit-new' if new_user else 'edit-existing' }}" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button" type="submit">Back</button>
+  <a name="task" href="/admin/user/edit" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Back</a>
   <button name="task" value="{{ 'confirm-new' if new_user else 'confirm-existing' }}" class="govuk-button" data-module="govuk-button" type="submit">{{ 'Save and invite new user' if new_user else 'Save changes' }}</button>
 </form>
 

--- a/templates/admin/edit-user.html
+++ b/templates/admin/edit-user.html
@@ -142,7 +142,7 @@
   </div>
 
   <div>
-    <button name="task" value="{{ 'cancel-new' if new_user else 'cancel-existing' }}" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button" type="submit">Cancel</button>
+    <a name="task" href="{{ '/admin' if new_user else '/admin/user' }}" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Cancel</a>
     <button name="task" value="{{ 'continue-new' if new_user else 'continue-existing' }}" class="govuk-button govuk-!-margin-right-1" data-module="govuk-button" data-prevent-double-click="true" type="submit">Continue and check</button>
   </div>
 

--- a/templates/admin/edit-user.html
+++ b/templates/admin/edit-user.html
@@ -1,6 +1,7 @@
 {% extends 'primary.html' %}
 {% block content %}
 
+<h1 class="govuk-heading-l">Edit user</h1>
 <form action="/admin/user/confirm" method="post">
 
   <div class="govuk-form-group">

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,7 +1,7 @@
 {% extends 'primary.html' %}
 {% block content %}
 
-
+<h1 class="govuk-heading-l">User administration</h1>
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
     <h2 class="govuk-fieldset__heading">
@@ -11,10 +11,10 @@
 
   <form action="/admin/user" method="post">
     <div class="govuk-form-group">
-      <label class="govuk-label" for="name">
+      <label class="govuk-label" for="email">
         Email address
       </label>
-      <input class="govuk-input" name="email" type="email" spellcheck="false">
+      <input class="govuk-input" id="email" name="email" type="email" spellcheck="false">
     </div>
     <button name="task" value="view" class="govuk-button" data-module="govuk-button" type=submit>Go to user</button>
   </form>

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -4,9 +4,9 @@
 
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-    <h1 class="govuk-fieldset__heading">
+    <h2 class="govuk-fieldset__heading">
       View user
-    </h1>
+    </h2>
   </legend>
 
   <form action="/admin/user" method="post">
@@ -22,9 +22,9 @@
 
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-    <h1 class="govuk-fieldset__heading">
+    <h2 class="govuk-fieldset__heading">
       New user
-    </h1>
+    </h2>
   </legend>
   <form action="/admin/user/edit" method="post">
     <button name="task" value="new" class="govuk-button" data-module="govuk-button" type="submit">New user</button>

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -11,10 +11,10 @@
 
   <form action="/admin/user" method="post">
     <div class="govuk-form-group">
-      <label class="govuk-label" for="email">
+      <label class="govuk-label" for="input-email">
         Email address
       </label>
-      <input class="govuk-input" id="email" name="email" type="email" spellcheck="false">
+      <input class="govuk-input" id="input-email" name="email" type="email" spellcheck="false">
     </div>
     <button name="task" value="view" class="govuk-button" data-module="govuk-button" type=submit>Go to user</button>
   </form>

--- a/templates/admin/user.html
+++ b/templates/admin/user.html
@@ -1,6 +1,8 @@
 {% extends 'primary.html' %}
 {% block content %}
 
+<h1 class="govuk-heading-l">Manage user</h1>
+
 {%if done != "None" %}
   <div class="govuk-panel govuk-panel--confirmation">
     <h2 class="govuk-panel__title">
@@ -14,7 +16,7 @@
     <dt class="govuk-summary-list__key">
       Enabled
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_enabled">
       {{ "Yes" if user.enabled|string == 'True' else "No" }}
     </dd>
   </div>
@@ -22,7 +24,7 @@
     <dt class="govuk-summary-list__key">
       Status
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_status">
       {{ user.status }}
     </dd>
   </div>
@@ -30,7 +32,7 @@
     <dt class="govuk-summary-list__key">
       Full name
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_name">
       {{ user.name|e }}
     </dd>
   </div>
@@ -38,7 +40,7 @@
     <dt class="govuk-summary-list__key">
       Email address
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_email">
       {{ user.email }}
     </dd>
   </div>
@@ -46,7 +48,7 @@
     <dt class="govuk-summary-list__key">
       UK mobile number
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_phone_number">
       {% if user.phone_number_verified == 'true' %}
         {{ user.phone_number }} (VERIFIED)
       {% else %}
@@ -58,7 +60,7 @@
     <dt class="govuk-summary-list__key">
       Account type
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_account_type">
       <p class="govuk-body">{{ user_group['display'] }}</p>
     </dd>
   </div>
@@ -66,7 +68,7 @@
     <dt class="govuk-summary-list__key">
       Local authority user?
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_is_local_authority">
       {{ "Yes" if user["custom:is_la"] == "1" else "No" }}
     </dd>
   </div>
@@ -74,9 +76,9 @@
     <dt class="govuk-summary-list__key">
       Paths
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_granted_paths">
       {% for attr_path in user["custom:paths"].split(";") %}
-        <p class="govuk-body">{{ attr_path }}</p>
+        <p class="govuk-body">{{ attr_path | s3_remove_root_path }}</p>
       {% endfor %}
     </dd>
   </div>
@@ -84,7 +86,7 @@
     <dt class="govuk-summary-list__key">
       Created date (last invited)
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_created">
       {{ user.createdate }}
     </dd>
   </div>
@@ -92,7 +94,7 @@
     <dt class="govuk-summary-list__key">
       Last modified date
     </dt>
-    <dd class="govuk-summary-list__value">
+    <dd class="govuk-summary-list__value" id="user_modified">
       {{ user.lastmodifieddate }}
     </dd>
   </div>

--- a/templates/admin/user.html
+++ b/templates/admin/user.html
@@ -108,10 +108,11 @@
 <p>The following actions will ask for confirmation</p>
 <div>
   <form action="/admin/user/edit" method="post">
-    <button name="task" value="reinvite" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Reinvite</button>
-    <button name="task" value="{{ 'disable' if user.enabled|string == 'True' else 'enable' }}" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">{{ 'Disable' if user.enabled|string == 'True' else 'Enable' }}</button>
+    <button formaction="/admin/user/reinvite" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Reinvite</button>
+    <button name="task" value="{{ 'disable' if user.enabled|string == 'True' else 'enable' }}" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">{{ 'Disable' if user.enabled|string == 'True' else 'Enable' }}</button><form action="/admin/user/edit" method="post">
     <button name="task" value="delete" class="govuk-button govuk-button--secondary" data-module="govuk-button">Delete</button>
   </form>
+
 </div>
 
 {% endblock %}

--- a/templates/admin/user.html
+++ b/templates/admin/user.html
@@ -101,7 +101,7 @@
 <div>
   <form action="/admin/user/edit" method="post">
     <button name="task" value="edit" class="govuk-button govuk-button govuk-!-margin-right-1" data-module="govuk-button" type="submit">Edit</button>
-    <button name="task" value="cancel" class="govuk-button govuk-button--secondary" data-module="govuk-button" type="submit">Back to admin</button>
+    <a name="task" href="/admin" class="govuk-button govuk-button--secondary" data-module="govuk-button">Back to admin</a>
   </form>
 </div>
 

--- a/templates/admin/user.html
+++ b/templates/admin/user.html
@@ -109,7 +109,7 @@
 <div>
   <form action="/admin/user/edit" method="post">
     <button formaction="/admin/user/reinvite" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Reinvite</button>
-    <button name="task" value="{{ 'disable' if user.enabled|string == 'True' else 'enable' }}" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">{{ 'Disable' if user.enabled|string == 'True' else 'Enable' }}</button><form action="/admin/user/edit" method="post">
+    <button formaction="/admin/user/{{ 'disable' if user.enabled else 'enable' }}" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">{{ 'Disable' if user.enabled else 'Enable' }}</button>
     <button name="task" value="delete" class="govuk-button govuk-button--secondary" data-module="govuk-button">Delete</button>
   </form>
 

--- a/templates/admin/user.html
+++ b/templates/admin/user.html
@@ -107,10 +107,10 @@
 
 <p>The following actions will ask for confirmation</p>
 <div>
-  <form action="/admin/user/edit" method="post">
+  <form method="post">
     <button formaction="/admin/user/reinvite" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">Reinvite</button>
     <button formaction="/admin/user/{{ 'disable' if user.enabled else 'enable' }}" class="govuk-button govuk-button--secondary govuk-!-margin-right-1" data-module="govuk-button">{{ 'Disable' if user.enabled else 'Enable' }}</button>
-    <button name="task" value="delete" class="govuk-button govuk-button--secondary" data-module="govuk-button">Delete</button>
+    <button formaction="/admin/user/delete" class="govuk-button govuk-button--secondary" data-module="govuk-button">Delete</button>
   </form>
 
 </div>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,41 @@
+import re
+
+from logger import LOG
+
+
+def flatten_html(body: str) -> str:
+    """
+    Remove whitespace around html element tags.
+    """
+    # remove whitespace after html tags
+    flat = re.sub(r"\>\s+", ">", body)
+    # remove whitespace before html tags
+    flat = re.sub(r"\s+\<", "<", flat)
+    return flat
+
+
+def body_has_element_with_attributes(body: str, attributes: dict) -> bool:
+    element_pattern = r"(\<[^\>]+\>)"
+    matches = re.findall(element_pattern, body)
+    found_matching_element = False
+    for element in matches:
+        attributes_found = {}
+        for attribute_name, attribute_value in attributes.items():
+            find_string = f'{attribute_name}="{attribute_value}"'
+            attributes_found[attribute_name] = find_string in element
+
+        # Print out the stuff you've found for partial matches
+        # for test debugging
+        if True in list(attributes_found.values()):
+            LOG.debug(element)
+            LOG.debug(attributes)
+            LOG.debug(attributes_found)
+            LOG.debug(list(attributes_found.values()))
+
+        # You don't want to assign the variable directly
+        if all(attributes_found.values()):
+            found_matching_element = True
+            # You only need one match
+            break
+
+    return found_matching_element

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,7 +21,11 @@ def body_has_element_with_attributes(body: str, attributes: dict) -> bool:
     for element in matches:
         attributes_found = {}
         for attribute_name, attribute_value in attributes.items():
-            find_string = f'{attribute_name}="{attribute_value}"'
+            if attribute_value:
+                find_string = f'{attribute_name}="{attribute_value}"'
+            else:
+                find_string = attribute_name
+
             attributes_found[attribute_name] = find_string in element
 
         # Print out the stuff you've found for partial matches

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -1,7 +1,6 @@
 """ Create mock boto3 clients for testing """
 
 import boto3
-import pytest
 from botocore.stub import Stubber
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,7 +1,7 @@
 import pytest
+import stubs
 from werkzeug.datastructures import ImmutableMultiDict
 
-import stubs
 from admin import (
     parse_edit_form_fields,
     perform_cognito_task,
@@ -75,7 +75,6 @@ def test_requested_path_matches_user_type():
 @pytest.mark.usefixtures("admin_user")
 def test_perform_cognito_task(admin_user):
     stubber = stubs.mock_cognito_create_user(admin_user)
-    # TODO: stub additional responses in stubs.mock_cognito_create_user
     with stubber:
         assert perform_cognito_task("confirm-new", admin_user)
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,83 @@
+import pytest
+from werkzeug.datastructures import ImmutableMultiDict
+
+from admin import (
+    parse_edit_form_fields,  
+    perform_cognito_task,
+    requested_path_matches_user_type,
+)
+from main import app
+import stubs
+
+
+@pytest.mark.usefixtures("admin_user")
+@pytest.mark.usefixtures("user_confirm_form")
+def test_parse_edit_form_fields(admin_user, user_confirm_form):
+
+    # Check that correct changes are made for valid form data
+    user = parse_edit_form_fields(
+        ImmutableMultiDict(user_confirm_form), admin_user, app
+    )
+    assert "web-app-prod-data/local_authority/barnet" in user["custom:paths"]
+    assert "web-app-prod-data/local_authority/hackney" in user["custom:paths"]
+    assert user["group"]["value"] == "standard-upload"
+
+    # Check that invalid form data is sanitised safely
+    dirty_form = {}
+    dirty_form.update(user_confirm_form)
+    dirty_form["full-name"] = 'Justin Casey"; test'
+    user = parse_edit_form_fields(ImmutableMultiDict(dirty_form), admin_user, app)
+    assert user["name"] == "Justin Casey&#34;; test"
+
+    # Check that non local authority users are denied access to local authority paths
+    invalid_path_form = {}
+    invalid_path_form.update(user_confirm_form)
+    invalid_path_form["is-la-radio"] = "no"
+    user = parse_edit_form_fields(
+        ImmutableMultiDict(invalid_path_form), admin_user, app
+    )
+    assert user["custom:is_la"] == "0"
+    assert user["custom:paths"] == ""
+
+    # Check that local authority users are denied access to non local authority paths
+    invalid_path_form = {}
+    invalid_path_form.update(user_confirm_form)
+    invalid_path_form["is-la-radio"] = "yes"
+    invalid_path_form["custom_paths"] = ["web-app-prod-data/other/nhs"]
+    user = parse_edit_form_fields(
+        ImmutableMultiDict(invalid_path_form), admin_user, app
+    )
+    assert user["custom:is_la"] == "1"
+    assert user["custom:paths"] == ""
+
+    # Check that non local authority user can be granted access to NHS data
+    valid_nhs_form = {}
+    valid_nhs_form.update(user_confirm_form)
+    valid_nhs_form["is-la-radio"] = "no"
+    valid_nhs_form["custom_paths"] = ["web-app-prod-data/other/nhs"]
+    user = parse_edit_form_fields(ImmutableMultiDict(valid_nhs_form), admin_user, app)
+    assert user["custom:is_la"] == "0"
+    assert user["custom:paths"] == "web-app-prod-data/other/nhs"
+
+
+def test_requested_path_matches_user_type():
+
+    assert requested_path_matches_user_type(
+        True, "web-app-prod-data/local_authority/barnet"
+    )
+    assert not requested_path_matches_user_type(
+        False, "web-app-prod-data/local_authority/barnet"
+    )
+    assert requested_path_matches_user_type(False, "web-app-prod-data/other/nhs")
+    assert not requested_path_matches_user_type(True, "web-app-prod-data/other/nhs")
+
+
+@pytest.mark.usefixtures("admin_user")
+def test_perform_cognito_task(admin_user):
+    stubber = stubs.mock_cognito_create_user(admin_user)
+    # TODO: stub additional responses in stubs.mock_cognito_create_user
+
+    with stubber:
+        assert perform_cognito_task("confirm-new", admin_user)
+        
+        stubber.deactivate()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,13 +1,13 @@
 import pytest
 from werkzeug.datastructures import ImmutableMultiDict
 
+import stubs
 from admin import (
-    parse_edit_form_fields,  
+    parse_edit_form_fields,
     perform_cognito_task,
     requested_path_matches_user_type,
 )
 from main import app
-import stubs
 
 
 @pytest.mark.usefixtures("admin_user")
@@ -76,8 +76,7 @@ def test_requested_path_matches_user_type():
 def test_perform_cognito_task(admin_user):
     stubber = stubs.mock_cognito_create_user(admin_user)
     # TODO: stub additional responses in stubs.mock_cognito_create_user
-
     with stubber:
         assert perform_cognito_task("confirm-new", admin_user)
-        
+
         stubber.deactivate()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,8 +4,8 @@ import os
 import flask
 import pytest
 import requests_mock
-
 import stubs
+
 from main import (
     app,
     create_presigned_url,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -178,7 +178,7 @@ def test_auth_flow(test_client, test_session, fake_jwt_decoder, **args):
     app.client_id = "123456"
     app.client_secret = "987654"
     app.redirect_host = "test.domain.com"
-    stubber = stubs.mock_cognito(token)
+    stubber = stubs.mock_cognito_auth_flow(token)
 
     with test_client.session_transaction() as client_session:
         client_session.update(test_session)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,8 +4,8 @@ import os
 import flask
 import pytest
 import requests_mock
-import stubs
 
+import stubs
 from main import (
     app,
     create_presigned_url,


### PR DESCRIPTION
Mock cognito calls for cognito.get_user_details. 
Refactor admin_edit_user and admin_confirm_user into a number of smaller functions. 
Unit tests for functions in admin modules. 
Integration style tests for a couple of flask routes in the admin module. 
Refactor task redirect buttons into link tags to simplify route logic. 
Add element IDs to form elements to fix form accessibility of label tags.
Refactor the user denied path logic in admin_edit_user for existing users 
(remove existing invalid paths).  