### PR TITLE
Enable create and edit of users with admin roles

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -282,9 +282,12 @@ def admin_edit_user(app):
         # If you are editing an existing user:
         # - check that all the granted paths are valid for the user's type.
         # - and remove any paths where the account type doesn't match
+        if "custom:paths" not in admin_user_object:
+            admin_user_object["custom:paths"] = ""
         is_local_authority_user = admin_user_object["custom:is_la"] == "1"
         is_other_user = not is_local_authority_user
         admin_user_object = remove_invalid_user_paths(admin_user_object)
+
 
     return render_template_custom(
         app,

--- a/cognito.py
+++ b/cognito.py
@@ -282,13 +282,14 @@ def list_users(email_starts_filter="", token="", limit=20):
     return {"users": users, "token": token}
 
 
-def return_false_if_paths_bad(is_la_value, paths_semicolon_seperated):
-    if paths_semicolon_seperated == "":
+def are_user_paths_valid(is_la_value, paths_semicolon_separated, group_name):
+
+    if "admin" not in group_name and paths_semicolon_separated == "":
         return False
 
     app_authorised_paths = [os.getenv("BUCKET_MAIN_PREFIX", "web-app-prod-data")]
     for authed_path in app_authorised_paths:
-        for path_re_split_for_check in paths_semicolon_seperated.split(";"):
+        for path_re_split_for_check in paths_semicolon_separated.split(";"):
 
             # if current/new attr for is_la is 0 (not a local authority)
             # then don't allow local local_authority paths to be set
@@ -412,7 +413,8 @@ def create_user(user):
     if phone_number == "":
         return False
 
-    if not return_false_if_paths_bad(is_la, attr_paths):
+    # only check paths for non-admin users
+    if not are_user_paths_valid(is_la, attr_paths, group_name):
         return False
 
     response = {}
@@ -585,8 +587,8 @@ def update_user_attributes(user):
 
         if new_paths is not None:
             if isinstance(new_paths, str):
-
-                if not return_false_if_paths_bad(is_la_value, new_paths):
+                group_name = new_group_name if new_group_name is not None else user["group"]["value"]
+                if not are_user_paths_valid(is_la_value, new_paths, group_name):
                     return False
 
                 attrs.append({"Name": "custom:paths", "Value": new_paths})

--- a/js/main.js
+++ b/js/main.js
@@ -21,6 +21,7 @@ function load_account_switch_js() {
   var x = document.getElementById("account-select");
   if (x != null) {
     x.addEventListener('change', function() { account_switch(this.value); });
+    account_switch(x.value)
   }
 }
 

--- a/templates/admin/edit-user.html
+++ b/templates/admin/edit-user.html
@@ -95,10 +95,11 @@
               <div class="govuk-checkboxes">
                 {% for i in other.subs %}
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" name="custom_paths" type="checkbox" value="{{ i['val'] }}" {{
-                    'checked="checked"' if i['val'] in user_custom_paths
-                  }}>
-                  <label class="govuk-label govuk-checkboxes__label" for="custom_paths">
+                  <input class="govuk-checkboxes__input"
+                         name="custom_paths" type="checkbox"
+                         id="custom_path_{{ i['val'] }}"
+                         value="{{ i['val'] }}" {{ 'checked="checked"' if i['val'] in user_custom_paths }}>
+                  <label class="govuk-label govuk-checkboxes__label" for="custom_path_{{ i['val'] }}">
                     {{ i['disp'] }}<br>
                     <span class="govuk-hint">
                       {{ i['val'] }}
@@ -121,10 +122,10 @@
               <div class="govuk-checkboxes">
                 {% for i in local_authority.subs %}
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" name="custom_paths" type="checkbox" value="{{ i['val'] }}" {{
+                  <input class="govuk-checkboxes__input" name="custom_paths" id="custom_path_{{ i['val'] }}" type="checkbox" value="{{ i['val'] }}" {{
                     'checked="checked"' if i['val'] in user_custom_paths
                   }}>
-                  <label class="govuk-label govuk-checkboxes__label" for="custom_paths">
+                  <label class="govuk-label govuk-checkboxes__label" for="custom_path_{{ i['val'] }}">
                     {{ i['disp'] }}<br>
                     <span class="govuk-hint">
                       {{ i['val'] }}

--- a/templates/admin/user.html
+++ b/templates/admin/user.html
@@ -72,6 +72,7 @@
       {{ "Yes" if user["custom:is_la"] == "1" else "No" }}
     </dd>
   </div>
+  {% if "custom:paths" in user %}
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       Paths
@@ -82,6 +83,7 @@
       {% endfor %}
     </dd>
   </div>
+  {% endif %}
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       Created date (last invited)

--- a/templates/primary.html
+++ b/templates/primary.html
@@ -118,12 +118,8 @@
       <div class="govuk-footer__meta">
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
 
-          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-            <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-          </svg>
           <span class="govuk-footer__licence-description">
-            All content is available under the
-            <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+            Access to this service is provided by invitation only.
           </span>
         </div>
         <div class="govuk-footer__meta-item">
@@ -134,7 +130,7 @@
   </footer>
 
   <script src="/js/govuk-frontend-3.6.0.min.js"></script>
-  <script src="/js/main.js?update=20200407-1959"></script>
+  <script src="/js/main.js?update=20200417-0931"></script>
   {% block scriptblock %}
   {% endblock %}
 </body>


### PR DESCRIPTION
Formerly custom:paths = "" was invalid which means you couldn't assign someone to an admin role or edit someone with an admin role. 
It's not the most elegant fix but it works. The path validation now also takes into consideration the user's current (or to-be-assigned) role. 
Fix typo in variable name seperated > separated.

+ Drive-by fix for OGL statement in the page footer because it was bugging me.