### PR TITLE
Create lambda handler

### DIFF
--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -1,0 +1,27 @@
+import os
+import app
+import serverless_wsgi
+
+
+def web_app(event, context):
+    """Lambda handler entry point for web app.
+        :param event: An event from an ALB
+        :param context: An AWS context object
+        :returns: An AWS ALB event
+        :rtype: dict
+    """
+    return serverless_wsgi.handle_request(app.app, event, context)
+
+
+def admin(event, context):
+    """Lambda handler entry point for admin app.
+    Designates the environment as ADMIN.
+    Ensures correct user management: admin users cannot upload or download objects from S3
+    but do have permission to edit the cognito pool.
+        :param event: An event from an ALB
+        :param context: An AWS context object
+        :returns: An AWS ALB event
+        :rtype: dict
+    """
+    os.environ["ADMIN"] = "true"
+    return serverless_wsgi.handle_request(app.app, event, context)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests == 2.23.*
 flask-talisman == 0.7.0
 py3-validate-email == 0.2.0
 idna >= 2.8
+serverless_wsgi == 1.7.4


### PR DESCRIPTION
Creates two lambda handlers for the web-app and admin apps. 
Adds `serverless_wsgi` as a requirement.