### PR TITLE
Add missing hubs.csv file to packaged lambda.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ copy_dir:
 	set -e
 	echo "⏳ copying..."
 	cp *.py .target
+	cp hubs.csv .target
 	cp *.yml .target
 	cp *.txt .target
 	cp -R assets .target


### PR DESCRIPTION
The make zip task wasn't adding the hubs.csv file to the lambda package which meant the admin tool couldn't run.