### PR TITLE
Implement restrictions on new users function for all groups except "admin-full"

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-04-20T12:05:21Z",
+  "generated_at": "2020-05-01T14:18:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -60,7 +60,7 @@
         "hashed_secret": "dea742e166979027ae70b28e0a9006fb1010e760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 179,
+        "line_number": 166,
         "type": "Secret Keyword"
       }
     ]

--- a/admin.py
+++ b/admin.py
@@ -90,9 +90,7 @@ def admin_list_users(app):
 def admin_main(app):
     clear_session(app)
     return render_template_custom(
-        app,
-        "admin/index.html",
-        can_create_users=user_has_a_valid_role(["admin-full"])
+        app, "admin/index.html", can_create_users=user_has_a_valid_role(["admin-full"])
     )
 
 

--- a/admin.py
+++ b/admin.py
@@ -6,7 +6,7 @@ from requests.utils import quote
 
 import s3paths
 from cognito_groups import get_group_by_name, return_users_group, user_groups
-from flask_helpers import render_template_custom
+from flask_helpers import render_template_custom, user_has_a_valid_role
 from user import User
 
 local_valid_paths_var = []
@@ -89,7 +89,11 @@ def admin_list_users(app):
 
 def admin_main(app):
     clear_session(app)
-    return render_template_custom(app, "admin/index.html")
+    return render_template_custom(
+        app,
+        "admin/index.html",
+        can_create_users=user_has_a_valid_role(["admin-full"])
+    )
 
 
 def admin_confirm_user(app):
@@ -257,6 +261,10 @@ def admin_edit_user(app):
 
         session["admin_user_email"] = ""
         session["admin_user_object"] = {}
+
+        # only admin-full can create a new user
+        if not user_has_a_valid_role(["admin-full"]):
+            return redirect("/403")
 
     admin_user_email = session["admin_user_email"]
     admin_user_object = session["admin_user_object"]

--- a/behave/features/8.admin.feature
+++ b/behave/features/8.admin.feature
@@ -5,6 +5,8 @@ Feature: COVID19 Data Transfer - Admin page
         Given credentials for the "admin-view" group
         When you login with these credentials
         Then you can go to the admin page
+        Then the button "Go to user" does exist
+        Then the button "New user" does not exist
 
     @admin
     Scenario: Logged in as an admin-power user
@@ -19,6 +21,8 @@ Feature: COVID19 Data Transfer - Admin page
         Given credentials for the "admin-full" group
         When you login with these credentials
         Then you can go to the admin page
+        Then the button "Go to user" does exist
+        Then the button "New user" does exist
 
     @admin
     Scenario: Logged in as a standard-download user

--- a/behave/features/8.admin.feature
+++ b/behave/features/8.admin.feature
@@ -11,6 +11,8 @@ Feature: COVID19 Data Transfer - Admin page
         Given credentials for the "admin-power" group
         When you login with these credentials
         Then you can go to the admin page
+        Then the button "Go to user" does exist
+        Then the button "New user" does not exist
 
     @admin
     Scenario: Logged in as an admin-full user

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -1,5 +1,6 @@
 import time
 
+from selenium.common.exceptions import NoSuchElementException
 from behave import then, when
 
 
@@ -22,6 +23,32 @@ def click_on_button(context, text):
     )
     elem.click()
     time.sleep(5)
+
+
+@then('the button "{text}" does exist')
+def button_is_there(context, text):
+    try:
+        context.browser.find_element_by_xpath(
+            "//*[contains(@class, 'govuk-button')][text()[contains(., '{}')]]".format(text)
+        )
+        element_found = True
+    except NoSuchElementException:
+        element_found = False
+
+    assert element_found
+
+
+@then('the button "{text}" does not exist')
+def button_is_not_there(context, text):
+    try:
+        context.browser.find_element_by_xpath(
+            "//*[contains(@class, 'govuk-button')][text()[contains(., '{}')]]".format(text)
+        )
+        element_found = True
+    except NoSuchElementException:
+        element_found = False
+
+    assert not element_found
 
 
 @when('field with name "{selector}" is given "{value}"')

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -21,8 +21,14 @@ def has_admin_role():
 def user_has_a_valid_role(valid_roles):
     has_a_valid_role = False
     group = session.get("group", None)
+    LOG.debug(group)
+    LOG.debug(session.get("user", None))
     if group:
         has_a_valid_role = group["value"] in valid_roles
+        if not has_a_valid_role:
+            LOG.debug({"group": group, "valid": valid_roles})
+    else:
+        LOG.debug("No group in session")
     return has_a_valid_role
 
 

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -18,6 +18,14 @@ def has_admin_role():
     return is_admin_role
 
 
+def user_has_a_valid_role(valid_roles):
+    has_a_valid_role = False
+    group = session.get("group", None)
+    if group:
+        has_a_valid_role = group["value"] in valid_roles
+    return has_a_valid_role
+
+
 def current_group_name():
     default_group_name = "group-not-available"
     group_name = default_group_name

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -20,6 +20,7 @@
   </form>
 </fieldset>
 
+{% if can_create_users %}
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
     <h2 class="govuk-fieldset__heading">
@@ -30,5 +31,6 @@
     <button name="task" value="new" class="govuk-button" data-module="govuk-button" type="submit">New user</button>
   </form>
 </fieldset>
+{% endif %}
 
 {% endblock %}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -13,12 +13,7 @@ from helpers import body_has_element_with_attributes, flatten_html
 from main import app
 
 
-@pytest.mark.usefixtures("admin_user")
-@pytest.mark.usefixtures("user_confirm_form")
-@pytest.mark.usefixtures("test_client")
-@pytest.mark.usefixtures("test_session")
-@pytest.mark.usefixtures("user_details_response")
-@pytest.mark.usefixtures("test_admin_session")
+@pytest.mark.usefixtures("admin_user", "user_confirm_form")
 def test_parse_edit_form_fields(admin_user, user_confirm_form):
 
     # Check that correct changes are made for valid form data
@@ -81,6 +76,7 @@ def test_requested_path_matches_user_type():
     assert not requested_path_matches_user_type(False, "")
 
 
+@pytest.mark.usefixtures("admin_user")
 def test_remove_invalid_user_paths(admin_user):
     granted_paths = admin_user["custom:paths"].split(";")
     granted_paths.sort()
@@ -104,6 +100,7 @@ def test_remove_invalid_user_paths(admin_user):
     assert user["custom:paths"] == ""
 
 
+@pytest.mark.usefixtures("admin_user")
 def test_perform_cognito_task(admin_user):
     with patch("admin.User.create") as mocked_user_get_details:
         mocked_user_get_details.return_value = True
@@ -115,6 +112,7 @@ def test_perform_cognito_task(admin_user):
 # so they seem to fit better in here.
 
 
+@pytest.mark.usefixtures("test_client", "test_admin_session")
 def test_route_admin(test_client, test_admin_session):
     with test_client.session_transaction() as client_session:
         client_session.update(test_admin_session)
@@ -125,6 +123,9 @@ def test_route_admin(test_client, test_admin_session):
     assert '<h1 class="govuk-heading-l">User administration</h1>' in body
 
 
+@pytest.mark.usefixtures(
+    "test_client", "test_admin_session", "admin_user", "user_details_response"
+)
 def test_route_admin_user(
     test_client, test_admin_session, admin_user, user_details_response
 ):
@@ -143,6 +144,9 @@ def test_route_admin_user(
         assert 'id="user_email">' + admin_user["email"] + "<" in flat
 
 
+@pytest.mark.usefixtures(
+    "test_client", "test_admin_session", "admin_user", "user_details_response"
+)
 def test_route_admin_user_edit(
     test_client, test_admin_session, admin_user, user_details_response
 ):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,12 +20,6 @@ from main import (
 )
 
 
-@pytest.mark.usefixtures("test_client")
-@pytest.mark.usefixtures("test_session")
-@pytest.mark.usefixtures("test_upload_session")
-@pytest.mark.usefixtures("upload_form_fields")
-@pytest.mark.usefixtures("valid_extensions")
-@pytest.mark.usefixtures("upload_form_fields")
 def test_css():
     with app.test_request_context("/css/govuk-frontend-3.6.0.min.css"):
         assert flask.request.view_args["path"] == "govuk-frontend-3.6.0.min.css"
@@ -53,11 +47,13 @@ def test_dist():
 # Test the flask routes
 
 
+@pytest.mark.usefixtures("test_client")
 def test_route_index_logged_out(test_client):
     response = test_client.get("/")
     assert response.status_code == 200
 
 
+@pytest.mark.usefixtures("test_client", "test_session")
 def test_route_index_logged_in(test_client, test_session):
     with test_client.session_transaction() as client_session:
         client_session.update(test_session)
@@ -71,6 +67,7 @@ def test_route_index_logged_in(test_client, test_session):
     )
 
 
+@pytest.mark.usefixtures("test_client", "test_upload_session")
 def test_route_index_logged_in_upload(test_client, test_upload_session):
     with test_client.session_transaction() as client_session:
         client_session.update(test_upload_session)
@@ -81,6 +78,7 @@ def test_route_index_logged_in_upload(test_client, test_upload_session):
     assert "<h3>Upload</h3>" in body
 
 
+@pytest.mark.usefixtures("test_client", "test_session")
 def test_route_files(test_client, test_session):
     with test_client.session_transaction() as client_session:
         client_session.update(test_session)
@@ -109,6 +107,7 @@ def test_route_files(test_client, test_session):
         assert "local_authority/haringey/people4.csv" in body
 
 
+@pytest.mark.usefixtures("test_client", "test_session")
 def test_route_upload_denied(test_client, test_session):
     with test_client.session_transaction() as client_session:
         client_session.update(test_session)
@@ -119,6 +118,7 @@ def test_route_upload_denied(test_client, test_session):
     assert "<h1>Redirecting...</h1>" in body
 
 
+@pytest.mark.usefixtures("test_client", "test_upload_session")
 def test_route_upload_allowed(test_client, test_upload_session):
     with test_client.session_transaction() as client_session:
         client_session.update(test_upload_session)
@@ -129,6 +129,7 @@ def test_route_upload_allowed(test_client, test_upload_session):
     assert '<h3 class="govuk-heading-m">File settings</h3>' in body
 
 
+@pytest.mark.usefixtures("test_client")
 def test_route_css(test_client):
     """ Check CSS actually resolves successfully """
     response = test_client.get("/css/govuk-frontend-3.6.0.min.css")
@@ -137,6 +138,7 @@ def test_route_css(test_client):
     assert ".govuk-link{" in body
 
 
+@pytest.mark.usefixtures("test_client")
 def test_route_js(test_client):
     """ Check JS actually resolves successfully """
     response = test_client.get("/js/govuk-frontend-3.6.0.min.js")
@@ -151,8 +153,9 @@ def test_route_js(test_client):
     assert "!function(a,b)" in body
 
 
+@pytest.mark.usefixtures("test_client", "test_session")
 @requests_mock.Mocker(kw="mocker")
-def test_auth_flow(test_client, test_session, fake_jwt_decoder, **args):
+def test_auth_flow(test_client, test_session, **args):
     """ Test mocked oauth exchange """
 
     token = "abc123"
@@ -184,11 +187,13 @@ def test_auth_flow(test_client, test_session, fake_jwt_decoder, **args):
 # Test access management functions
 
 
+@pytest.mark.usefixtures("test_session")
 def test_return_attribute(test_session):
     user_attribute_value = return_attribute(test_session, "custom:is_la")
     assert user_attribute_value == "1"
 
 
+@pytest.mark.usefixtures("test_session")
 def test_load_user_lookup(test_session):
     root_path = "web-app-prod-data"
     paths = load_user_lookup(test_session)
@@ -311,6 +316,7 @@ def test_get_files(test_session):
         stubber.deactivate()
 
 
+@pytest.mark.usefixtures("test_session")
 def test_create_presigned_url(test_session):
     """ Test creation of presigned url """
     bucket = "test_bucket"
@@ -325,6 +331,7 @@ def test_create_presigned_url(test_session):
         stubber.deactivate()
 
 
+@pytest.mark.usefixtures("test_session")
 def test_user_custom_paths(test_session):
     download_paths = user_custom_paths(test_session, is_upload=False)
     assert "web-app-prod-data/local_authority/haringey" in download_paths
@@ -332,6 +339,7 @@ def test_user_custom_paths(test_session):
     assert "web-app-upload/local_authority/barnet" in upload_paths
 
 
+@pytest.mark.usefixtures("test_session", "upload_form_fields", "valid_extensions")
 def test_upload_form_validate(test_session, upload_form_fields, valid_extensions):
     upload_paths = user_custom_paths(test_session, is_upload=True)
     validation_status = upload_form_validate(
@@ -354,6 +362,7 @@ def test_upload_form_validate(test_session, upload_form_fields, valid_extensions
     assert not validation_status["valid"]
 
 
+@pytest.mark.usefixtures("upload_form_fields")
 def test_generate_upload_file_path(upload_form_fields):
     file_path = generate_upload_file_path(upload_form_fields)
     assert file_path.startswith(upload_form_fields["file_location"])

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -5,18 +5,6 @@ import pytest
 from user import User
 
 
-@pytest.mark.usefixtures("valid_user")
-@pytest.mark.usefixtures("user_with_invalid_email")
-@pytest.mark.usefixtures("user_with_invalid_domain")
-@pytest.mark.usefixtures("group_result")
-@pytest.mark.usefixtures("admin_get_user")
-@pytest.mark.usefixtures("user_details_response")
-@pytest.mark.usefixtures("standard_download_group_response")
-@pytest.mark.usefixtures("user_details_response")
-@pytest.mark.usefixtures("create_user_arguments")
-@pytest.mark.usefixtures("list_users_arguments")
-@pytest.mark.usefixtures("list_users_response")
-@pytest.mark.usefixtures("list_users_result")
 def test_email_sanitised_on_init():
     test1 = "anormalemail@example.gov.uk"
     assert User(test1).email_address == test1
@@ -25,6 +13,9 @@ def test_email_sanitised_on_init():
     assert User(" anemail@example.gov.uk ").email_address == "anemail@example.gov.uk"
 
 
+@pytest.mark.usefixtures(
+    "valid_user", "user_with_invalid_email", "user_with_invalid_domain"
+)
 def test_email_address_is_valid(
     valid_user, user_with_invalid_email, user_with_invalid_domain
 ):
@@ -33,6 +24,9 @@ def test_email_address_is_valid(
     assert not user_with_invalid_domain.email_address_is_valid()
 
 
+@pytest.mark.usefixtures(
+    "valid_user", "admin_get_user", "standard_download_group_response"
+)
 def test_accessor_functions(
     valid_user, admin_get_user, standard_download_group_response
 ):
@@ -51,11 +45,13 @@ def test_accessor_functions(
         assert not valid_user.is_la()
 
 
+@pytest.mark.usefixtures("valid_user", "user_with_invalid_domain")
 def test_allowed_domains_rejects_invalid_domain(valid_user, user_with_invalid_domain):
     assert valid_user.domain_is_allowed()
     assert not user_with_invalid_domain.domain_is_allowed()
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_allowed_domains(valid_user):
     assert [
         ".gov.uk",
@@ -74,36 +70,43 @@ def test_allowed_domains(valid_user):
     ] == valid_user.allowed_domains()
 
 
+@pytest.mark.usefixtures("user_with_invalid_email")
 def test_delete_with_invalid_email(user_with_invalid_email):
     assert not user_with_invalid_email.delete()
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_delete_with_valid_email(monkeypatch, valid_user):
     with patch("user.make_request") as mocked_send:
         assert valid_user.delete()
         mocked_send.assert_called_with("admin_delete_user", valid_user.email_address)
 
 
+@pytest.mark.usefixtures("user_with_invalid_email")
 def test_enable_with_invalid_email(user_with_invalid_email):
     assert not user_with_invalid_email.enable()
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_enable_with_valid_email(monkeypatch, valid_user):
     with patch("user.make_request") as mocked_send:
         assert valid_user.enable()
         mocked_send.assert_called_with("admin_enable_user", valid_user.email_address)
 
 
+@pytest.mark.usefixtures("user_with_invalid_email")
 def test_disable_with_invalid_email(user_with_invalid_email):
     assert not user_with_invalid_email.disable()
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_disable_with_valid_email(monkeypatch, valid_user):
     with patch("user.make_request") as mocked_send:
         assert valid_user.disable()
         mocked_send.assert_called_with("admin_disable_user", valid_user.email_address)
 
 
+@pytest.mark.usefixtures("valid_user", "admin_get_user", "user_details_response")
 def test_normalise(valid_user, admin_get_user, user_details_response):
     with patch("user.make_request") as mocked_send:
         result = User.normalise(admin_get_user)
@@ -113,6 +116,12 @@ def test_normalise(valid_user, admin_get_user, user_details_response):
         assert result == user_details_response
 
 
+@pytest.mark.usefixtures(
+    "valid_user",
+    "admin_get_user",
+    "standard_download_group_response",
+    "user_details_response",
+)
 def test_details(
     monkeypatch,
     valid_user,
@@ -131,6 +140,7 @@ def test_details(
         mocked_send.assert_has_calls(expected_calls)
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_sanitise_phone(valid_user):
     assert valid_user.sanitise_phone("+441234567890") == "+441234567890"
     assert valid_user.sanitise_phone("441234567890") == "+441234567890"
@@ -139,12 +149,14 @@ def test_sanitise_phone(valid_user):
     assert valid_user.sanitise_phone("notaphonenumber") == ""
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_sanitise_name(valid_user):
     assert valid_user.sanitise_name("joe bloggs") == "joebloggs"
     assert valid_user.sanitise_name("joe_bloggs") == "joe_bloggs"
     assert valid_user.sanitise_name("joe bloggs 2") == "joebloggs2"
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_update_returns_false_if_user_not_found(valid_user):
     with patch.object(valid_user, "get_details", return_value={}):
         assert not valid_user.update(
@@ -152,11 +164,13 @@ def test_update_returns_false_if_user_not_found(valid_user):
         )
 
 
+@pytest.mark.usefixtures("valid_user", "admin_get_user")
 def test_update_returns_false_if_new_details_are_all_none(valid_user, admin_get_user):
     with patch.object(valid_user, "get_details", return_value=admin_get_user):
         assert not valid_user.update(None, None, None, None, None)
 
 
+@pytest.mark.usefixtures("valid_user", "admin_get_user")
 def test_update_returns_false_if_new_details_are_not_strings(
     valid_user, admin_get_user
 ):
@@ -164,6 +178,9 @@ def test_update_returns_false_if_new_details_are_not_strings(
         assert not valid_user.update(0, 1, 2, 3, 4)
 
 
+@pytest.mark.usefixtures(
+    "valid_user", "admin_get_user", "user_details_response", "group_result"
+)
 def test_update(valid_user, admin_get_user, user_details_response, group_result):
     make_request_results = [
         admin_get_user,
@@ -211,6 +228,9 @@ def test_update(valid_user, admin_get_user, user_details_response, group_result)
         mocked_send.assert_has_calls(expected_calls)
 
 
+@pytest.mark.usefixtures(
+    "valid_user", "admin_get_user", "user_details_response", "group_result"
+)
 def test_update_will_not_change_group_if_unchanged(
     valid_user, admin_get_user, user_details_response, group_result
 ):
@@ -245,6 +265,7 @@ def test_update_will_not_change_group_if_unchanged(
         mocked_send.assert_has_calls(expected_calls)
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_set_mfa_preferences(valid_user):
     with patch("user.make_request") as mocked_send:
         valid_user.set_mfa_preferences()
@@ -258,6 +279,7 @@ def test_set_mfa_preferences(valid_user):
         )
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_set_user_settings(valid_user):
     with patch("user.make_request") as mocked_send:
         valid_user.set_user_settings()
@@ -271,6 +293,7 @@ def test_set_user_settings(valid_user):
         )
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_add_to_group(valid_user):
     # Returns false if invalid group included
     assert not valid_user.add_to_group("not_a_group")
@@ -305,11 +328,13 @@ def test_add_to_group(valid_user):
             )
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_user_paths_are_valid_returns_false_if_not_admin_and_path_is_blank(valid_user):
     assert not valid_user.user_paths_are_valid("1", "", "standard-download")
     assert not valid_user.user_paths_are_valid("1", "", "standard-upload")
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_user_paths_are_valid_non_la_users_can_only_get_non_la_paths(
     monkeypatch, valid_user
 ):
@@ -322,6 +347,7 @@ def test_user_paths_are_valid_non_la_users_can_only_get_non_la_paths(
     )
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_user_paths_are_valid_la_users_can_only_get_la_paths(monkeypatch, valid_user):
     monkeypatch.setenv("BUCKET_MAIN_PREFIX", "ambridge")
     assert valid_user.user_paths_are_valid(
@@ -333,6 +359,7 @@ def test_user_paths_are_valid_la_users_can_only_get_la_paths(monkeypatch, valid_
     )
 
 
+@pytest.mark.usefixtures("valid_user", "user_with_invalid_email")
 def test_create_returns_false_if_checks_fail(
     monkeypatch, valid_user, user_with_invalid_email
 ):
@@ -347,6 +374,7 @@ def test_create_returns_false_if_checks_fail(
     )
 
 
+@pytest.mark.usefixtures("valid_user", "create_user_arguments")
 def test_create(monkeypatch, valid_user, create_user_arguments):
     with patch("cognito.make_request") as mocked_cognito_send:
         mocked_cognito_send.return_value = True
@@ -355,9 +383,11 @@ def test_create(monkeypatch, valid_user, create_user_arguments):
         )
 
 
+@pytest.mark.usefixtures("valid_user", "create_user_arguments")
 def test_create_when_create_returns_false(
     monkeypatch, valid_user, create_user_arguments
 ):
+
     with patch("cognito.make_request") as mocked_cognito_send:
         mocked_cognito_send.return_value = False
         with patch("user.make_request") as mocked_send:
@@ -391,6 +421,7 @@ def test_create_when_create_returns_false(
             mocked_send.assert_has_calls(expected_calls)
 
 
+@pytest.mark.usefixtures("valid_user", "user_details_response")
 def test_reinvite(monkeypatch, valid_user, user_details_response):
     with patch.object(User, "get_details", return_value=user_details_response):
         with patch.object(User, "delete", return_value=True):
@@ -398,11 +429,13 @@ def test_reinvite(monkeypatch, valid_user, user_details_response):
                 assert valid_user.reinvite()
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_reinvite_returns_false_if_user_does_not_exist(monkeypatch, valid_user):
     with patch.object(User, "get_details", return_value={}):
         assert not valid_user.reinvite()
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_reinvite_returns_false_if_user_exists_but_cannot_be_deleted(
     monkeypatch, valid_user
 ):
@@ -411,6 +444,7 @@ def test_reinvite_returns_false_if_user_exists_but_cannot_be_deleted(
             assert not valid_user.reinvite()
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_reinvite_returns_false_if_user_exists_can_be_deleted_but_cannot_be_created(
     monkeypatch, valid_user
 ):
@@ -420,6 +454,9 @@ def test_reinvite_returns_false_if_user_exists_can_be_deleted_but_cannot_be_crea
                 assert not valid_user.reinvite()
 
 
+@pytest.mark.usefixtures(
+    "list_users_arguments", "list_users_response", "group_result", "list_users_result"
+)
 def test_list(
     monkeypatch,
     list_users_arguments,
@@ -435,6 +472,9 @@ def test_list(
             mocked_send.assert_called_with("list_users", "", list_users_arguments, True)
 
 
+@pytest.mark.usefixtures(
+    "list_users_arguments", "list_users_response", "group_result", "list_users_result"
+)
 def test_list_includes_arguments(
     monkeypatch,
     list_users_arguments,
@@ -459,6 +499,7 @@ def test_list_includes_arguments(
             mocked_send.assert_called_with("list_users", "", list_users_arguments, True)
 
 
+@pytest.mark.usefixtures("valid_user", "group_result")
 def test_group_returns_default_group_if_none_returned(
     monkeypatch, valid_user, group_result
 ):
@@ -471,6 +512,7 @@ def test_group_returns_default_group_if_none_returned(
         )
 
 
+@pytest.mark.usefixtures("valid_user")
 def test_group_returns_correct_group(monkeypatch, valid_user):
     with patch("user.make_request") as mocked_send:
         expected_results = [

--- a/user.py
+++ b/user.py
@@ -198,7 +198,7 @@ class User:
                 # then don't allow local_authority paths to be set
                 if is_la == "0":
                     if path.startswith(la_path):
-                        LOG.info("%s: won't set non-LA user to: %s" "user-admin", path)
+                        LOG.info("%s: won't set non-LA user to: %s", "user-admin", path)
                         return False
                 # if new attr for is_la is 1 (IS local authority)
                 # then only allow local_authority paths to be set


### PR DESCRIPTION
Implements a helper function user_has_a_valid_role which takes a list of valid group names. 
Hides new user functions from all but "admin-full" group members. 
Redirects user to /403 if a non "admin-full" user reaches the /admin/user/edit route with target=new.