### PR TITLE
Fix setting mfa on new user

### DIFF
--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -1,4 +1,5 @@
 import requests
+
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 

--- a/behave/features/steps/admin.py
+++ b/behave/features/steps/admin.py
@@ -1,9 +1,8 @@
 import os
 
-from selenium.webdriver.support.select import Select
-
 import user_routes
 from behave import then, when
+from selenium.webdriver.support.select import Select
 
 
 @then("you can go to the admin page")

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -1,7 +1,7 @@
 import time
 
-from selenium.common.exceptions import NoSuchElementException
 from behave import then, when
+from selenium.common.exceptions import NoSuchElementException
 
 
 @when('visit url "{url}"')
@@ -29,7 +29,9 @@ def click_on_button(context, text):
 def button_is_there(context, text):
     try:
         context.browser.find_element_by_xpath(
-            "//*[contains(@class, 'govuk-button')][text()[contains(., '{}')]]".format(text)
+            "//*[contains(@class, 'govuk-button')][text()[contains(., '{}')]]".format(
+                text
+            )
         )
         element_found = True
     except NoSuchElementException:
@@ -42,7 +44,9 @@ def button_is_there(context, text):
 def button_is_not_there(context, text):
     try:
         context.browser.find_element_by_xpath(
-            "//*[contains(@class, 'govuk-button')][text()[contains(., '{}')]]".format(text)
+            "//*[contains(@class, 'govuk-button')][text()[contains(., '{}')]]".format(
+                text
+            )
         )
         element_found = True
     except NoSuchElementException:

--- a/conftest.py
+++ b/conftest.py
@@ -248,14 +248,24 @@ def group_result():
 def create_user_arguments():
     return {
         "UserAttributes": [
-            {"Name": "name", "Value": "justin"},
+            {"Name": "name", "Value": "Justin Casey"},
             {"Name": "email", "Value": "justin.casey@communities.gov.uk"},
             {"Name": "email_verified", "Value": "true"},
-            {"Name": "phone_number", "Value": "+44201234567890"},
+            {"Name": "phone_number", "Value": "+447123456789"},
             {"Name": "phone_number_verified", "Value": "false"},
-            {"Name": "custom:is_la", "Value": "0"},
-            {"Name": "custom:paths", "Value": "web-app-prod-data"},
+            {"Name": "custom:is_la", "Value": "1"},
+            {
+                "Name": "custom:paths",
+                "Value": ";".join(
+                    [
+                        "web-app-prod-data/local_authority/barking",
+                        "web-app-prod-data/local_authority/haringey",
+                    ]
+                ),
+            },
         ],
+        "UserPoolId": "eu-west-2_poolid",
+        "Username": "justin.casey@communities.gov.uk",
         "ForceAliasCreation": False,
         "DesiredDeliveryMediums": ["EMAIL"],
     }

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -1,6 +1,7 @@
 import os
 
 import serverless_wsgi
+
 from main import app, load_environment, setup_talisman
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 import flask
 import pytest
 import requests_mock
-
 import stubs
+
 from main import (
     app,
     create_presigned_url,

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -375,15 +375,6 @@ def test_create_returns_false_if_checks_fail(
     )
 
 
-# @pytest.mark.usefixtures("valid_user", "create_user_arguments")
-# def test_create(monkeypatch, valid_user, create_user_arguments):
-#     with patch("cognito.make_request") as mocked_cognito_send:
-#         mocked_cognito_send.return_value = True
-#         assert valid_user.create(
-#             "justin", "0201234567890", "web-app-prod-data", "0", "standard-download"
-#         )
-
-
 @pytest.mark.usefixtures("admin_user", "create_user_arguments")
 def test_create(admin_user, create_user_arguments):
     group_name = admin_user["group"]["value"]
@@ -401,42 +392,6 @@ def test_create(admin_user, create_user_arguments):
         stubber.deactivate()
 
 
-# @pytest.mark.usefixtures("valid_user", "create_user_arguments")
-# def test_create_when_create_returns_false(
-#     monkeypatch, valid_user, create_user_arguments
-# ):
-#
-#     with patch("cognito.make_request") as mocked_cognito_send:
-#         mocked_cognito_send.return_value = False
-#         with patch("user.make_request") as mocked_send:
-#             assert valid_user.create(
-#                 "justin", "0201234567890", "web-app-prod-data", "0", "standard-download"
-#             )
-#             mocked_cognito_send.assert_called_with(
-#                 "admin_create_user", valid_user.email_address, create_user_arguments
-#             )
-#             expected_calls = [
-#                 call(
-#                     "admin_set_user_mfa_preference",
-#                     valid_user.email_address,
-#                     {"SMSMfaSettings": {"Enabled": True, "PreferredMfa": True}},
-#                 ),
-#                 call(
-#                     "admin_set_user_settings",
-#                     valid_user.email_address,
-#                     {
-#                         "MFAOptions": [
-#                             {"DeliveryMedium": "SMS", "AttributeName": "phone_number"}
-#                         ]
-#                     },
-#                 ),
-#                 call(
-#                     "admin_add_user_to_group",
-#                     valid_user.email_address,
-#                     {"GroupName": "standard-download"},
-#                 ),
-#             ]
-#             mocked_send.assert_has_calls(expected_calls)
 @pytest.mark.usefixtures("admin_user", "create_user_arguments")
 def test_creating_invalid_phone_number(admin_user, create_user_arguments):
     group_name = admin_user["group"]["value"]

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,6 +1,7 @@
 from unittest.mock import call, patch
 
 import pytest
+import stubs
 
 from user import User
 
@@ -374,51 +375,83 @@ def test_create_returns_false_if_checks_fail(
     )
 
 
-@pytest.mark.usefixtures("valid_user", "create_user_arguments")
-def test_create(monkeypatch, valid_user, create_user_arguments):
-    with patch("cognito.make_request") as mocked_cognito_send:
-        mocked_cognito_send.return_value = True
-        assert valid_user.create(
-            "justin", "0201234567890", "web-app-prod-data", "0", "standard-download"
+# @pytest.mark.usefixtures("valid_user", "create_user_arguments")
+# def test_create(monkeypatch, valid_user, create_user_arguments):
+#     with patch("cognito.make_request") as mocked_cognito_send:
+#         mocked_cognito_send.return_value = True
+#         assert valid_user.create(
+#             "justin", "0201234567890", "web-app-prod-data", "0", "standard-download"
+#         )
+
+
+@pytest.mark.usefixtures("admin_user", "create_user_arguments")
+def test_create(admin_user, create_user_arguments):
+    group_name = admin_user["group"]["value"]
+    stubber = stubs.mock_cognito_create_user(admin_user, create_user_arguments)
+
+    with stubber:
+        test_user = User(admin_user["email"])
+        assert test_user.create(
+            admin_user["name"],
+            admin_user["phone_number"],
+            admin_user["custom:paths"],
+            admin_user["custom:is_la"],
+            group_name,
         )
+        stubber.deactivate()
 
 
-@pytest.mark.usefixtures("valid_user", "create_user_arguments")
-def test_create_when_create_returns_false(
-    monkeypatch, valid_user, create_user_arguments
-):
+# @pytest.mark.usefixtures("valid_user", "create_user_arguments")
+# def test_create_when_create_returns_false(
+#     monkeypatch, valid_user, create_user_arguments
+# ):
+#
+#     with patch("cognito.make_request") as mocked_cognito_send:
+#         mocked_cognito_send.return_value = False
+#         with patch("user.make_request") as mocked_send:
+#             assert valid_user.create(
+#                 "justin", "0201234567890", "web-app-prod-data", "0", "standard-download"
+#             )
+#             mocked_cognito_send.assert_called_with(
+#                 "admin_create_user", valid_user.email_address, create_user_arguments
+#             )
+#             expected_calls = [
+#                 call(
+#                     "admin_set_user_mfa_preference",
+#                     valid_user.email_address,
+#                     {"SMSMfaSettings": {"Enabled": True, "PreferredMfa": True}},
+#                 ),
+#                 call(
+#                     "admin_set_user_settings",
+#                     valid_user.email_address,
+#                     {
+#                         "MFAOptions": [
+#                             {"DeliveryMedium": "SMS", "AttributeName": "phone_number"}
+#                         ]
+#                     },
+#                 ),
+#                 call(
+#                     "admin_add_user_to_group",
+#                     valid_user.email_address,
+#                     {"GroupName": "standard-download"},
+#                 ),
+#             ]
+#             mocked_send.assert_has_calls(expected_calls)
+@pytest.mark.usefixtures("admin_user", "create_user_arguments")
+def test_creating_invalid_phone_number(admin_user, create_user_arguments):
+    group_name = admin_user["group"]["value"]
+    stubber = stubs.mock_cognito_create_user(admin_user, create_user_arguments)
 
-    with patch("cognito.make_request") as mocked_cognito_send:
-        mocked_cognito_send.return_value = False
-        with patch("user.make_request") as mocked_send:
-            assert valid_user.create(
-                "justin", "0201234567890", "web-app-prod-data", "0", "standard-download"
-            )
-            mocked_cognito_send.assert_called_with(
-                "admin_create_user", valid_user.email_address, create_user_arguments
-            )
-            expected_calls = [
-                call(
-                    "admin_set_user_mfa_preference",
-                    valid_user.email_address,
-                    {"SMSMfaSettings": {"Enabled": True, "PreferredMfa": True}},
-                ),
-                call(
-                    "admin_set_user_settings",
-                    valid_user.email_address,
-                    {
-                        "MFAOptions": [
-                            {"DeliveryMedium": "SMS", "AttributeName": "phone_number"}
-                        ]
-                    },
-                ),
-                call(
-                    "admin_add_user_to_group",
-                    valid_user.email_address,
-                    {"GroupName": "standard-download"},
-                ),
-            ]
-            mocked_send.assert_has_calls(expected_calls)
+    with stubber:
+        test_user = User(admin_user["email"])
+        assert not test_user.create(
+            admin_user["name"],
+            "",
+            admin_user["custom:paths"],
+            admin_user["custom:is_la"],
+            group_name,
+        )
+        stubber.deactivate()
 
 
 @pytest.mark.usefixtures("valid_user", "user_details_response")

--- a/user.py
+++ b/user.py
@@ -63,6 +63,11 @@ class User:
 
     def create(self, name, phone_number, custom_paths, is_la, group_name):
         phone_number = self.sanitise_phone(phone_number)
+
+        set_mfa = False
+        set_settings = False
+        added_to_group = False
+
         if not self.email_address_is_valid():
             return False
         if phone_number == "":
@@ -74,11 +79,9 @@ class User:
         )
 
         if user_created:
-            return True
-
-        set_mfa = self.set_mfa_preferences()
-        set_settings = self.set_user_settings()
-        added_to_group = self.add_to_group(group_name)
+            set_mfa = self.set_mfa_preferences()
+            set_settings = self.set_user_settings()
+            added_to_group = self.add_to_group(group_name)
         return set_mfa and set_settings and added_to_group
 
     def set_mfa_preferences(self):


### PR DESCRIPTION
Fix configuring MFA settings when creating new users

* We introduced a regression.
* We should not return True and escape out of the method when a new user is created.
* Once a user has been created we must configure the MFA settings, users settings, and add them to a group.