### PR TITLE
Enforce mfa on production login

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-05-07T15:44:30Z",
+  "generated_at": "2020-05-07T16:03:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -60,7 +60,7 @@
         "hashed_secret": "dea742e166979027ae70b28e0a9006fb1010e760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 198,
+        "line_number": 199,
         "type": "Secret Keyword"
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-05-01T14:18:31Z",
+  "generated_at": "2020-05-07T14:50:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -60,7 +60,7 @@
         "hashed_secret": "dea742e166979027ae70b28e0a9006fb1010e760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 166,
+        "line_number": 197,
         "type": "Secret Keyword"
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-05-07T14:50:01Z",
+  "generated_at": "2020-05-07T15:44:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -60,7 +60,7 @@
         "hashed_secret": "dea742e166979027ae70b28e0a9006fb1010e760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 197,
+        "line_number": 198,
         "type": "Secret Keyword"
       }
     ]

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -1,5 +1,4 @@
 import requests
-
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 

--- a/behave/features/steps/admin.py
+++ b/behave/features/steps/admin.py
@@ -1,8 +1,9 @@
 import os
 
+from selenium.webdriver.support.select import Select
+
 import user_routes
 from behave import then, when
-from selenium.webdriver.support.select import Select
 
 
 @then("you can go to the admin page")

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -1,7 +1,8 @@
 import time
 
-from behave import then, when
 from selenium.common.exceptions import NoSuchElementException
+
+from behave import then, when
 
 
 @when('visit url "{url}"')

--- a/conftest.py
+++ b/conftest.py
@@ -301,3 +301,28 @@ def list_users_result(user_details_response):
         "users": [user_details_response],
         "token": "",
     }
+
+
+@pytest.fixture()
+def test_no_mfa_user():
+    return {
+        "Username": "test-secrets",
+        "UserAttributes": [
+            {"Name": "custom:paths", "Value": "local_authority/barnet"},
+            {"Name": "custom:is_la", "Value": "1"},
+        ],
+    }
+
+
+@pytest.fixture()
+def test_mfa_user():
+    return {
+        "Username": "test-secrets",
+        "UserAttributes": [
+            {"Name": "custom:paths", "Value": "local_authority/barnet"},
+            {"Name": "custom:is_la", "Value": "1"},
+        ],
+        "MFAOptions": [{"DeliveryMedium": "SMS", "AttributeName": "phone_number"}],
+        "PreferredMfaSetting": "SMS_MFA",
+        "UserMFASettingList": ["SMS_MFA"],
+    }

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -1,7 +1,6 @@
 import os
 
 import serverless_wsgi
-
 from main import app, load_environment, setup_talisman
 
 

--- a/main.py
+++ b/main.py
@@ -123,10 +123,16 @@ def exchange_code_for_session_user(code, code_verifier=None) -> dict:
 
 
 def is_mfa_configured(cognito_user):
-    has_phone_mfa = True in [
-        device["DeliveryMedium"] == "SMS" and device["AttributeName"] == "phone_number"
-        for device in cognito_user.get("MFAOptions", [])
-    ]
+    # does the MFAOptions list contain an entry where both
+    # the DeliveryMedium is SMS
+    # and the AttributeName is phone_number
+    has_phone_mfa = any(
+        [
+            device["DeliveryMedium"] == "SMS"
+            and device["AttributeName"] == "phone_number"
+            for device in cognito_user.get("MFAOptions", [])
+        ]
+    )
 
     has_preferred_mfa_setting = cognito_user.get("PreferredMfaSetting", "") == "SMS_MFA"
     has_mfa_setting_list = "SMS_MFA" in cognito_user.get("UserMFASettingList", [])

--- a/main.py
+++ b/main.py
@@ -117,6 +117,10 @@ def exchange_code_for_session_user(code, code_verifier=None) -> dict:
         )
     # else oauth_response status code to 403
     else:
+        session["error_message"] = (
+            "Please contact us: "
+            "We need to enable SMS authentication for your account."
+        )
         oauth_response.status_code = 403
 
     return oauth_response

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -59,19 +59,13 @@ def mock_s3_list_objects(bucket_name, prefixes):
     return stubber
 
 
-def mock_cognito_auth_flow(token):
+def mock_cognito_auth_flow(token, test_user):
     _keep_it_real()
     client = boto3.real_client("cognito-idp")
 
     stubber = Stubber(client)
 
-    mock_get_user = {
-        "Username": "test-secrets",
-        "UserAttributes": [
-            {"Name": "custom:paths", "Value": "local_authority/barnet"},
-            {"Name": "custom:is_la", "Value": "1"},
-        ],
-    }
+    mock_get_user = test_user
 
     stubber.add_response("get_user", mock_get_user, {"AccessToken": token})
 
@@ -94,7 +88,7 @@ def mock_cognito_auth_flow(token):
     stubber.add_response(
         "admin_list_groups_for_user",
         mock_admin_list_groups_for_user,
-        {"UserPoolId": "eu-west-2_poolid", "Username": "test-secrets", "Limit": 10},
+        {"UserPoolId": "eu-west-2_poolid", "Username": "test-secrets"},
     )
 
     stubber.activate()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ from main import (
     key_has_granted_prefix,
     load_user_lookup,
     return_attribute,
+    setup_talisman,
     upload_form_validate,
     user_custom_paths,
 )
@@ -207,9 +208,6 @@ def test_auth_flow_with_no_mfa_user(
     mocker = args["mocker"]
     mocker.request(method="POST", url=token_endpoint_url, text=oauth_response)
     response = test_client.get(f"/?code={token}")
-
-    app.logger.debug("=====")
-    app.logger.debug(response.headers.get("Location"))
 
     body = response.data.decode()
     assert response.status_code == 302
@@ -445,3 +443,15 @@ def test_is_mfa_configured(test_mfa_user, test_no_mfa_user):
     test_wrong_preferred_device.update(test_mfa_user)
     test_wrong_preferred_device["PreferredMfaSetting"] = "Email_MFA"
     assert not is_mfa_configured(test_wrong_preferred_device)
+
+
+def test_setup_talisman():
+    app.cf_space = "testing"
+    talisman = setup_talisman(app)
+    assert not talisman.force_https
+    app.cf_space = "staging"
+    talisman = setup_talisman(app)
+    assert talisman.force_https
+    app.cf_space = "production"
+    talisman = setup_talisman(app)
+    assert talisman.force_https

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -194,6 +194,7 @@ def test_auth_flow_with_no_mfa_user(
     domain = "test.cognito.domain.com"
     token_endpoint_url = f"https://{domain}/oauth2/token"
     app.cognito_domain = domain
+    app.cf_space = "production"
     app.client_id = "123456"
     app.client_secret = "987654"
     app.redirect_host = "test.domain.com"

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,8 +1,8 @@
 from unittest.mock import call, patch
 
 import pytest
-import stubs
 
+import stubs
 from user import User
 
 

--- a/user.py
+++ b/user.py
@@ -360,4 +360,6 @@ class User:
         # Currently you can attach a list of users in cognito
         # but we're currently only interested in the first group
         group_name = None if len(groups) == 0 else groups[0]
+
+        LOG.debug("User group returns: %s", group_name)
         return get_group_by_name(group_name)


### PR DESCRIPTION
Ensure that if a cognito user has been created or updated to not use MFA, 
they are not able to login.

Add is_mfa_configured function and test 
Change exchange_code_for_tokens 
- rename to exchange_code_for_session_user
- return 403 status code if MFA not present in production
Change index route to redirect to 403 if auth function returns 403 status
Refactor setup_talisman and test 
