### PR TITLE
Bump Python runtime version

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.5
+python-3.7.7


### PR DESCRIPTION
The Python runtime version needs to be aligned with the Python version running in PaaS buildpack.