### PR TITLE
Add a check to ensure the log_level is not an empty string.

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -38,6 +38,13 @@ class JsonFormatter(logging.Formatter):
 
 def build_logger(log_name, log_level="ERROR"):
     """ Create shared logger and custom JSON handler """
+
+    # Default log_level value is only set for None
+    # If log level env var is set but empty string
+    # you still need to set the default value
+    if log_level == "":
+        log_level = "ERROR"
+
     logger = logging.getLogger(log_name)
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(JsonFormatter)
@@ -48,4 +55,5 @@ def build_logger(log_name, log_level="ERROR"):
 
 
 LOG_LEVEL = str(os.getenv("LOG_LEVEL", "ERROR"))
+
 LOG = build_logger("vulnerable_people_data_service", log_level=LOG_LEVEL)


### PR DESCRIPTION
Because docker-compose defaults missing env vars to empty string we now need to catch the case where the LOG_LEVEL is not set in the parent env so that when we call logger.setLevel we 
pass a valid argument.