### PR TITLE
Add test for CORS supported browsers.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -4,8 +4,14 @@ window.GOVUKFrontend.initAll();
 load_is_la_radio_js();
 load_account_switch_js();
 
+function main_console_log(message) {
+    if (typeof console == "undefined") {
+        console.log(message)
+    }
+}
+
 function load_is_la_radio_js() {
-  console.log("load_is_la_radio_js");
+  main_console_log("load_is_la_radio_js");
   var x = document.getElementsByName("is-la-radio");
   var i;
   for (i = 0; i < x.length; i++) {
@@ -17,7 +23,7 @@ function load_is_la_radio_js() {
 }
 
 function load_account_switch_js() {
-  console.log("load_account_switch_js");
+  main_console_log("load_account_switch_js");
   var x = document.getElementById("account-select");
   if (x != null) {
     x.addEventListener('change', function() { account_switch(this.value); });

--- a/js/s3upload.js
+++ b/js/s3upload.js
@@ -2,105 +2,137 @@
 
 load_s3upload_js();
 
+function s3_upload_console_log(message) {
+    if (typeof console == "undefined") {
+        console.log(message);
+    }
+}
+
 function load_s3upload_js() {
-  console.log("Loaded s3upload.js");
+    s3_upload_console_log("Loaded s3upload.js");
 
-  var x = document.getElementById("upload_submit");
-  if (x != null) {
-    x.addEventListener('click', function(e) { upload_submit_click(this, e); });
-  }
+    var x = document.getElementById("upload_submit");
+    if (x != null) {
+        x.addEventListener('click', function(e) { upload_submit_click(this, e); });
+    }
 
-  var fs = get_file_settings()
-  if (fs !== false) {
-    fs.file_location.addEventListener('change', file_name_change);
-    fs.file_name.addEventListener('keyup', file_name_change);
-    fs.file_ext.addEventListener('change', file_name_change);
-    file_name_change();
-  }
+    var fs = get_file_settings()
+    if (fs !== false) {
+        fs.file_location.addEventListener('change', file_name_change);
+        fs.file_name.addEventListener('keyup', file_name_change);
+        fs.file_ext.addEventListener('change', file_name_change);
+        file_name_change();
+    }
 }
 
 
 function get_file_settings() {
-  var file_location = document.getElementById("file_location");
-  if (file_location == null) {
-    return false;
-  }
+    var file_location = document.getElementById("file_location");
+    if (file_location == null) {
+        return false;
+    }
 
-  var file_name = document.getElementById("file_name");
-  var file_ext = document.getElementById("file_ext");
+    var file_name = document.getElementById("file_name");
+    var file_ext = document.getElementById("file_ext");
 
-  return {
-    "file_location": file_location,
-    "file_name": file_name,
-    "file_ext": file_ext
-  }
+    return {
+        "file_location": file_location,
+        "file_name": file_name,
+        "file_ext": file_ext
+    }
 }
 
 
 function file_name_change() {
-  var fs = get_file_settings()
-  if (fs !== false) {
-    var flv = fs.file_location.value;
-    var cds = current_datetime_string();
-    var fnv = fs.file_name.value;
-    if (fnv.trim() == "") {
-      fnv = "{file name}"
+    var fs = get_file_settings()
+    if (fs !== false) {
+        var flv = fs.file_location.value;
+        var cds = current_datetime_string();
+        var fnv = fs.file_name.value;
+        if (fnv.trim() == "") {
+            fnv = "{file name}"
+        }
+        var fev = fs.file_ext.value;
+
+        var new_file_name_display = flv + "/" + cds + "_" + fnv.trim() + "." + fev;
+
+        var dfp = document.getElementById("dynamic_file_path");
+        dfp.innerText = new_file_name_display;
     }
-    var fev = fs.file_ext.value;
-
-    var new_file_name_display = flv + "/" + cds + "_" + fnv.trim() + "." + fev;
-
-    var dfp = document.getElementById("dynamic_file_path");
-    dfp.innerText = new_file_name_display;
-  }
 }
 
 function current_datetime_string() {
-  var now = new Date();
-  var y = now.getFullYear();
-  var m = pad((now.getMonth() + 1), 2);
-  var d = pad(now.getDate(), 2);
-  var h = pad(now.getHours(), 2);
-  var min = pad(now.getMinutes(), 2);
-  var sec = pad(now.getSeconds(), 2);
-  return y + m + d + "_" + h + min + sec;
+    var now = new Date();
+    var y = now.getFullYear();
+    var m = pad((now.getMonth() + 1), 2);
+    var d = pad(now.getDate(), 2);
+    var h = pad(now.getHours(), 2);
+    var min = pad(now.getMinutes(), 2);
+    var sec = pad(now.getSeconds(), 2);
+    return y + m + d + "_" + h + min + sec;
 }
 
 function pad(n, width, z) {
-  z = z || '0';
-  n = n + '';
-  return n.length >= width ? n : new Array(width - n.length + 1).join(z) + n;
+    z = z || '0';
+    n = n + '';
+    return n.length >= width ? n : new Array(width - n.length + 1).join(z) + n;
 }
 
 // use the hidden filepathtoupload as the presignedurl
-function upload_submit_click(s, e) {
-  e.preventDefault();
+function upload_submit_click(element, event) {
 
-  var form_files = document.getElementById("file").files;
-  if (form_files.length != 1) {
-    alert("Please choose a file to upload.");
-    return false;
-  }
+    var do_default_html_form_submit = true;
 
-  uploading_panel = document.getElementById("uploading_panel");
-  uploading_panel.classList.remove("hidden");
+    //Detect browser support for CORS
+    if ('withCredentials' in new XMLHttpRequest()) {
+        /* supports cross-domain requests */
+        event.preventDefault();
 
-  uploading_panel = document.getElementById("upload_panel");
-  uploading_panel.classList.add("hidden");
+        var form_files = document.getElementById("file").files;
+        if (form_files.length != 1) {
 
-  start_upload();
+            alert("Please choose a file to upload.");
 
-  return false;
+        } else {
+
+            uploading_panel = document.getElementById("uploading_panel");
+            uploading_panel.classList.remove("hidden");
+
+            uploading_panel = document.getElementById("upload_panel");
+            uploading_panel.classList.add("hidden");
+
+            start_upload();
+
+        }
+        do_default_html_form_submit = false;
+    }
+    /*
+    // Investigate which browsers this will add support for
+    // and how to implement
+    else if(typeof XDomainRequest !== "undefined"){
+        //Use IE-specific "CORS" code with XDR
+        s3_upload_console_log("CORS supported (XDR)");
+    */
+    else {
+        alert(
+            "Please note: We can't detect the upload status for this browser. \n" +
+            "Please wait for an email confirmation of your file upload " +
+            "before leaving this page."
+        )
+    }
+
+
+    return do_default_html_form_submit;
 }
 
 function upload_complete(result) {
-  document.getElementById("upload_success").classList.remove("hidden");
-  document.getElementById("uploading_spinner").classList.add("hidden");
+    document.getElementById("upload_success").classList.remove("hidden");
+    document.getElementById("uploading_spinner").classList.add("hidden");
 }
 
 function upload_failed(result) {
-  document.getElementById("upload_failure").classList.remove("hidden");
-  document.getElementById("uploading_spinner").classList.add("hidden");
+    document.getElementById("upload_failure").classList.remove("hidden");
+    document.getElementById("uploading_spinner").classList.add("hidden");
 }
 
 //async function start_upload() {

--- a/templates/primary.html
+++ b/templates/primary.html
@@ -130,7 +130,7 @@
   </footer>
 
   <script src="/js/govuk-frontend-3.6.0.min.js"></script>
-  <script src="/js/main.js?update=20200417-0931"></script>
+  <script src="/js/main.js?update=20200521-1442"></script>
   {% block scriptblock %}
   {% endblock %}
 </body>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -111,5 +111,5 @@
 
 {% endblock %}
 {% block scriptblock %}
-  <script src="/js/s3upload.js?update=20200521-1101"></script>
+  <script src="/js/s3upload.js?update=20200521-1424"></script>
 {% endblock %}


### PR DESCRIPTION
Browsers with JS disabled should work.
For non-CORS JS enabled browsers we should now fall back on the no JS version with an alert.
For older IE we have added a function to check if console exists before console logging.

This should fix Windows 7 IE9.
It does not yet work for Windows 8 IE10 which claims CORS support but isn't working.