### PR TITLE
Remove unnecessary button wrapped in a link for login.

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -15,10 +15,8 @@
     <a href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a>.
   </p>
 
-  <a href="{{ login_url }}">
-    <button class="govuk-button covid-transfer-signin-button" data-module="govuk-button" id="signInButton" title="Sign In">
-      Sign In
-    </button>
+  <a href="{{ login_url }}" class="govuk-button covid-transfer-signin-button">
+    Sign In
   </a>
 
 {% endblock %}


### PR DESCRIPTION
Wrapping the href in a button is invalid markup.