### PR TITLE
Fix is_development function to stop the page title prefixing with PROD

### DIFF
--- a/config.py
+++ b/config.py
@@ -174,12 +174,14 @@ def get_cognito_pool_name():
         suffix = environment
 
     pool_name = f"{pool_name_prefix}-{suffix}"
-    LOG.debug({
-        "pool_name": pool_name,
-        "pool_name_prefix": pool_name_prefix,
-        "suffix": suffix,
-        "environment": environment
-    })
+    LOG.debug(
+        {
+            "pool_name": pool_name,
+            "pool_name_prefix": pool_name_prefix,
+            "suffix": suffix,
+            "environment": environment,
+        }
+    )
 
     set("cognito_pool_name", pool_name)
 
@@ -196,10 +198,7 @@ def env_pool_id():
                 pool_id = pool["id"]
                 break
 
-    LOG.debug({
-        "pool_name": pool_name,
-        "pool_id": pool_id
-    })
+    LOG.debug({"pool_name": pool_name, "pool_id": pool_id})
 
     return pool_id
 

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -42,7 +42,7 @@ def current_group_name():
 
 
 def is_development():
-    return config.get("app_environment", "production") != "production"
+    return config.get("app_environment", "prod") != "prod"
 
 
 def admin_interface(flask_route):

--- a/tests/test_flask_helpers.py
+++ b/tests/test_flask_helpers.py
@@ -37,7 +37,7 @@ def test_is_development():
     assert is_development()
     config.set("app_environment", "testing")
     assert is_development()
-    config.set("app_environment", "production")
+    config.set("app_environment", "prod")
     assert not is_development()
     config.delete("app_environment")
     assert not is_development()


### PR DESCRIPTION
The is_development function is now wrong because it's expecting app_environment to be "production" not "prod". 