### PR TITLE
Match the get_plus_string function to the env vars passed to the concourse worker in the pipeline.

### DIFF
--- a/behave/features/steps/user_routes.py
+++ b/behave/features/steps/user_routes.py
@@ -8,9 +8,10 @@ from behave import given, then, when
 
 def get_plus_string(group_name):
     # To keep things short I've truncated the stage name
-    # in the plus string from the APP_ENVIRONMENT env var
+    # in the plus string from the longer name used in the
+    # ENVIRONMENT env var
     stages = {"testing": "test", "staging": "stage"}
-    env = stages[os.environ.get("APP_ENVIRONMENT", "testing")]
+    env = stages[os.environ.get("ENVIRONMENT", "testing")]
 
     # for a stupid reason I created all the test users
     # with a slightly different naming convention


### PR DESCRIPTION
Previously this was set to APP_ENVIRONMENT which is not currently set in the pipeline job env.