### PR TITLE
Organise downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,3 +97,6 @@ concourse_e2e_lambda:
 	export LOG_LEVEL=DEBUG && cd behave && behave
 
 concourse_e2e: concourse_e2e_paas
+
+e2e_scenario: rebuild
+	docker-compose run chrome-driver bash -c "python3 run.py admin testing & cd behave && behave -n \"$(scenario)\""

--- a/behave/features/3.user_files.feature
+++ b/behave/features/3.user_files.feature
@@ -9,4 +9,4 @@ Feature: COVID19 Data Transfer - User files
         Then wait "5" seconds
         Then the content of element with selector ".covid-transfer-page-title" contains "COVID-19 Data Transfer"
         Then the content of element with selector "#main-content .covid-transfer-username" contains username
-        Then the content of element with selector "#main-content .covid-transfer-download-section a.covid-tranfer-file-link" equals "other/gds/not-real-data-other-gds.csv"
+        Then the content of element with selector "#main-content .covid-transfer-download-section a.covid-tranfer-file-link:first-of-type" equals "other/gds/not-real-data-other-gds.csv"

--- a/behave/features/3.user_files.feature
+++ b/behave/features/3.user_files.feature
@@ -9,4 +9,4 @@ Feature: COVID19 Data Transfer - User files
         Then wait "5" seconds
         Then the content of element with selector ".covid-transfer-page-title" contains "COVID-19 Data Transfer"
         Then the content of element with selector "#main-content .covid-transfer-username" contains username
-        Then the content of element with selector "#main-content .covid-transfer-download-section a.covid-tranfer-file-link:first-of-type" equals "other/gds/not-real-data-other-gds.csv"
+        Then the link with css selector "#main-content .covid-transfer-download-section a.covid-tranfer-file-link" and text "other/gds/not-real-data-other-gds.csv" does exist

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -94,3 +94,39 @@ def check_browser_title_step(context, title):
 @then('wait "{seconds}" seconds')
 def wait_step(context, seconds):
     time.sleep(int(seconds))
+
+
+@then('the link "{text}" does exist')
+def link_is_there(context, text):
+    try:
+        context.browser.find_element_by_xpath(
+            "//*[contains(@class, 'govuk-link')][text()[contains(., '{}')]]".format(
+                text
+            )
+        )
+        element_found = True
+    except NoSuchElementException:
+        element_found = False
+
+    assert element_found
+
+
+@then('the link with css selector "{selector}" and text "{text}" does exist')
+def link_with_selector_is_there(context, text, selector):
+    try:
+        context.browser.find_element_by_xpath(
+            "//*[contains(@class, 'govuk-link')][text()[contains(., '{}')]]".format(
+                text
+            )
+        )
+        link_found = True
+    except NoSuchElementException:
+        link_found = False
+
+    try:
+        context.browser.find_element_by_css_selector(selector)
+        selector_found = True
+    except NoSuchElementException:
+        selector_found = False
+
+    assert link_found and selector_found

--- a/conftest.py
+++ b/conftest.py
@@ -6,9 +6,9 @@ from datetime import datetime
 
 import pytest
 
+from config import load_environment
 from main import app
 from user import User
-from config import load_environment
 
 
 def get_standard_download_group():
@@ -350,8 +350,13 @@ def test_get_object():
 def test_list_object_file():
     now = datetime.utcnow()
     prefix = "web-app-prod-data/local_authority/barnet"
-    mock_list_object = {"Key": f"{prefix}/people1.csv", "Size": 100, "LastModified": now}
+    mock_list_object = {
+        "Key": f"{prefix}/people1.csv",
+        "Size": 100,
+        "LastModified": now,
+    }
     return mock_list_object
+
 
 @pytest.fixture()
 def test_ssm_parameters():

--- a/conftest.py
+++ b/conftest.py
@@ -347,6 +347,13 @@ def test_get_object():
 
 
 @pytest.fixture()
+def test_list_object_file():
+    now = datetime.utcnow()
+    prefix = "web-app-prod-data/local_authority/barnet"
+    mock_list_object = {"Key": f"{prefix}/people1.csv", "Size": 100, "LastModified": now}
+    return mock_list_object
+
+@pytest.fixture()
 def test_ssm_parameters():
     return {
         "/cognito/client_id": "abc123",

--- a/css/main.css
+++ b/css/main.css
@@ -20,3 +20,24 @@
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+.app-task-list__item {
+  border-bottom: 1px solid #b1b4b6;
+  margin-bottom: 0 !important;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.app-task-list__item:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid #b1b4b6;
+}
+
+.app-task-list__task-name {
+  display: block;
+}

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 from datetime import datetime
+from collections import defaultdict
 
 import boto3
 import requests
@@ -444,7 +445,7 @@ def files():
         "files.html",
         user=session["user"],
         email=session["email"],
-        files=files,
+        files=collect_by_date(files),
         is_la=return_attribute(session, "custom:is_la"),
     )
 
@@ -571,6 +572,7 @@ def get_files(bucket_name: str, user_session: dict):
 
     file_keys = []
     prefixes = load_user_lookup(user_session)
+    app.logger.debug({"prefixes": prefixes})
 
     for prefix in prefixes:
         paginator = conn.get_paginator("list_objects")
@@ -612,30 +614,60 @@ def categorise_file(file_item, prefix):
     """
     Take paths after the file prefix
     and words of the file name and
-    join into a single category
+    join into a single category string
     """
     key = file_item["Key"]
     file_path = key.replace(prefix, "")
+    # remove empty strings from starting or trailing slashes
     path_steps = list(filter(lambda folder: folder != "", file_path.split("/")))
     full_file_name = path_steps.pop()
-    # remove file extension
-    file_name = " ".join(full_file_name.split(".")[:-1])
-
-    file_name_words = file_name.split("-")
-    file_category_words = filter(lambda word: not re.match("^[0-9]+$", word), file_name_words)
-
-    path_steps.append(" ".join(file_category_words))
+    file_category = get_file_name_category(full_file_name)
+    if file_category != "":
+        path_steps.append(file_category)
 
     categories = [
-        re.sub(r"[-_]", " ", word).title()
+        re_case_word(re.sub(r"[-_]", " ", word))
         for word in path_steps
     ]
 
     joined_category = " > ".join(categories)
+    if re.search("^\s*$", joined_category):
+        joined_category = "Daily Incoming Data"
+
     app.logger.debug({"categories": categories, "joined": joined_category})
     file_item["Category"] = joined_category
     file_item["Categories"] = categories
     return file_item
+
+
+def get_file_name_category(file_name):
+    """
+    Strip any numeric strings from the file name
+    and convert to space delimited string for
+    rendering
+    """
+    # remove file extension
+    file_name = " ".join(file_name.split(".")[:-1])
+
+    file_name_words = file_name.split("-")
+    # remove numeric strings
+    file_category_words = filter(lambda word: not re.match("^[0-9]+$", word), file_name_words)
+
+    file_category = " ".join(file_category_words)
+    return file_category
+
+
+def re_case_word(word):
+    """
+    Title case word unless known initialism
+    """
+    initialisms = ["DWP", "NHS", "MHCLG", "GDS"]
+
+    if word.upper() in initialisms:
+        re_cased = word.upper()
+    else:
+        re_cased = word.title()
+    return re_cased
 
 
 def date_file(file_item):
@@ -649,6 +681,18 @@ def date_file(file_item):
     file_item["SortTime"] = file_item["LastModified"].strftime("%Y%m%dH%M")
     app.logger.debug({"date": file_item["SortDate"], "time": file_item["SortTime"]})
     return file_item
+
+
+def collect_by_date(file_items):
+    files_by_date = defaultdict(list)
+    file_count = len(file_items)
+    for file_item in file_items:
+        file_date = file_item["showdate"]
+        files_by_date[file_date].append(file_item)
+    return {
+        "by_date": files_by_date,
+        "count": file_count
+    }
 
 
 def return_attribute(session: dict, get_attribute: str) -> str:

--- a/templates/files.html
+++ b/templates/files.html
@@ -21,25 +21,38 @@
 
   <section class="covid-transfer-download-section">
     <div>
-      {% if files|length == 0 %}
+      {% if files.count == 0 %}
         There are no files currently available to download.
-      {% elif files|length == 1 %}
+      {% elif files.count == 1 %}
         There is 1 file available to download:
       {% else %}
-        There are {{ files|length }} files available to download:
+        There are {{ files.count }} files available to download:
       {% endif %}
     </div>
 
     <div>
-      <ul class="govuk-list">
-      {% for file in files %}
+      <ul class="app-task-list">
+        {% for file_date in files.by_date %}
+        {% set date_files = files.by_date[file_date] %}
         <li>
-          <!--span>{{ file.category }}</span><br/-->
-          <a target="_blank" class="govuk-link covid-tranfer-file-link" href="{{ file.url }}">
-            {{ file.key | s3_remove_root_path }}
-          </a> ({{ file.size|filesizeformat }})
+          <h3 class="app-task-list__section">
+            {{ file_date }}
+          </h3>
+          <ul class="app-task-list__items">
+            {% for file in date_files %}
+            <li class="app-task-list__item">
+
+              <span class="app-task-list__task-name">
+                <span>{{ file.category }} ({{ file.size|filesizeformat }})</span><br/>
+                <a target="_blank" class="govuk-link covid-tranfer-file-link" href="{{ file.url }}">
+                  {{ file.key | s3_remove_root_path }}
+                </a>
+              </span>
+            </li>
+            {% endfor %}
+          </ul>
         </li>
-      {% endfor %}
+        {% endfor %}
       </ul>
     </div>
   </section>

--- a/templates/files.html
+++ b/templates/files.html
@@ -34,6 +34,7 @@
       <ul class="govuk-list">
       {% for file in files %}
         <li>
+          <!--span>{{ file.category }}</span><br/-->
           <a target="_blank" class="govuk-link covid-tranfer-file-link" href="{{ file.url }}">
             {{ file.key | s3_remove_root_path }}
           </a> ({{ file.size|filesizeformat }})

--- a/templates/files.html
+++ b/templates/files.html
@@ -31,14 +31,14 @@
     </div>
 
     <div>
-      <ul class="app-task-list">
+      <ul class="app-task-list govuk-list">
         {% for file_date in files.by_date %}
         {% set date_files = files.by_date[file_date] %}
         <li>
           <h3 class="app-task-list__section">
             {{ file_date }}
           </h3>
-          <ul class="app-task-list__items">
+          <ul class="app-task-list__items govuk-list">
             {% for file in date_files %}
             <li class="app-task-list__item">
 

--- a/templates/primary.html
+++ b/templates/primary.html
@@ -42,7 +42,7 @@
     <script src="/dist/html5shiv.min.js"></script>
   <![endif]-->
 
-  <link href="/css/main.css?update=20200407-1026" rel="stylesheet">
+  <link href="/css/main.css?update=20200527-1000" rel="stylesheet">
 
   <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
 </head>

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -480,11 +480,16 @@ def stub_response_ssm_get_parameters_by_path(stubber, path, parameters):
 
 # Client: s3
 def stub_response_s3_list_objects_page_1(stubber, bucket_name, prefix):
+    now = datetime.utcnow()
     mock_list_objects_1 = {
         "Contents": [
-            {"Key": f"{prefix}/people1.csv", "Size": 100},
-            {"Key": f"{prefix}/people2.csv", "Size": 200},
-            {"Key": f"{prefix}/nested/nested_people1.csv", "Size": 300},
+            {"Key": f"{prefix}/people1.csv", "Size": 100, "LastModified": now},
+            {"Key": f"{prefix}/people2.csv", "Size": 200, "LastModified": now},
+            {
+                "Key": f"{prefix}/nested/nested_people1.csv",
+                "Size": 300,
+                "LastModified": now,
+            },
         ],
         "IsTruncated": True,
         "NextMarker": "page-2",
@@ -496,10 +501,11 @@ def stub_response_s3_list_objects_page_1(stubber, bucket_name, prefix):
 
 
 def stub_response_s3_list_objects_page_2(stubber, bucket_name, prefix):
+    now = datetime.utcnow()
     mock_list_objects_2 = {
         "Contents": [
-            {"Key": f"{prefix}/people3.csv", "Size": 100},
-            {"Key": f"{prefix}/people4.csv", "Size": 200},
+            {"Key": f"{prefix}/people3.csv", "Size": 100, "LastModified": now},
+            {"Key": f"{prefix}/people4.csv", "Size": 200, "LastModified": now},
         ]
     }
 


### PR DESCRIPTION
Present files for downloads grouped by date with the newest files highest on the page. 
Show readable text alongside the file link text to help put the different file types in context.
Fix end to end tests so we're not reliant on the position of the download link on the page. 