### PR TITLE
Use load_ssm_parameters to retrieve a session secret to set app.secret_key

### DIFF
--- a/config.py
+++ b/config.py
@@ -104,7 +104,7 @@ def load_ssm_parameters(app):
         "/cognito/client_secret": "client_secret",  # pragma: allowlist secret
         "/cognito/domain": "cognito_domain",
         "/s3/bucket_name": "bucket_name",
-        "/flask/secret_key": "secret_key"
+        "/flask/secret_key": "secret_key",
     }
 
     ssm_client = boto3.client("ssm")

--- a/conftest.py
+++ b/conftest.py
@@ -365,6 +365,7 @@ def test_ssm_parameters():
         "/cognito/client_secret": "def456",  # pragma: allowlist secret
         "/cognito/domain": "example.com",
         "/s3/bucket_name": "my_bucket",
+        "/flask/secret_key": "my_secret_key",
     }
 
 

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -34,5 +34,5 @@ def admin(event, context):
 def run(event, context):
     config.setup_talisman(app)
     config.load_environment(app)
-    config.load_ssm_parameters()
+    config.load_ssm_parameters(app)
     return serverless_wsgi.handle_request(app, event, context)

--- a/run.py
+++ b/run.py
@@ -11,7 +11,7 @@ def run():
     """
     config.setup_talisman(app)
     config.load_environment(app)
-    ssm_loaded = config.load_ssm_parameters()
+    ssm_loaded = config.load_ssm_parameters(app)
     if ssm_loaded:
         app.run(host="0.0.0.0", port=os.getenv("PORT", "8000"))
     else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,10 +38,11 @@ def test_read_env_variables():
 
 @pytest.mark.usefixtures("test_ssm_parameters")
 def test_load_ssm_parameters(test_ssm_parameters):
+    app = Flask(__name__)
     path = "/transfer-coronavirus-data-service"
     stubber = stubs.mock_config_load_ssm_parameters(path, test_ssm_parameters)
     with stubber:
-        config.load_ssm_parameters()
+        config.load_ssm_parameters(app)
         assert config.get("client_id") == test_ssm_parameters["/cognito/client_id"]
         assert (
             config.get("client_secret") == test_ssm_parameters["/cognito/client_secret"]


### PR DESCRIPTION
According to the [Flask quickstart](https://flask.palletsprojects.com/en/1.1.x/quickstart/) this should be set as app.secret_key rather than in app.config.
This means we need to pass app to load_ssm_parameters in run and lambda_handler.