### PR TITLE
Improve error handling for /admin/user/error route

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -65,7 +65,15 @@ def admin_user(app):
 
 
 def admin_user_error(app):
-    return render_template_custom(app, "admin/user-error.html")
+    error_message = session.get("error_message", "Something went wrong")
+    app.logger.error(f"Server error: {error_message}")
+    del session["error_message"]
+    return (
+        render_template_custom(
+            app, "error.html", hide_logout=True, error=error_message
+        ),
+        403,
+    )
 
 
 def sanitise_string(instr):
@@ -138,6 +146,8 @@ def admin_confirm_user(app):
             target = "/admin/user?done={}&email={}".format(
                 state, quote(admin_user_object["email"])
             )
+        # If this fails an error message should have been added to the session
+        # by the user.create or user.update methods.
         clear_session(app)
         return redirect(target)
 

--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@ import os
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError, ParamValidationError
+from flask import session
 
 from flask_talisman import Talisman
 
@@ -230,3 +231,19 @@ def set(setting_name, value=None):
 
 def delete(setting_name):
     del CONFIG[setting_name]
+
+
+def set_session_var(name, value=None):
+    try:
+        session[name] = value
+    except RuntimeError as err:
+        LOG.error("Failed to set variable is session: " + str(err))
+
+
+def get_session_var(name, default=None):
+    try:
+        value = session.get(name, default)
+    except RuntimeError as err:
+        LOG.error("Failed to get variable from session: " + str(err))
+        value = None
+    return value

--- a/main.py
+++ b/main.py
@@ -165,6 +165,7 @@ def send_browser_config():
 def server_error_403():
     error_message = session.get("error_message", "Access denied")
     app.logger.error(f"Server error: {error_message}")
+    del session["error_message"]
     return (
         render_template_custom(
             app, "error.html", hide_logout=True, error=error_message

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -108,6 +108,8 @@ def mock_cognito_create_user_set_mfa_fails(admin_user, create_user_arguments):
     stub_response_cognito_admin_add_user_to_group(
         stubber, admin_user["email"], group_name
     )
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_disable_user(stubber, admin_user["email"])
 
     stubber.activate()
     # override boto.client to return the mock client
@@ -143,6 +145,8 @@ def mock_cognito_create_user_set_user_settings_fails(admin_user, create_user_arg
     stub_response_cognito_admin_add_user_to_group(
         stubber, admin_user["email"], group_name
     )
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_disable_user(stubber, admin_user["email"])
 
     stubber.activate()
     # override boto.client to return the mock client
@@ -178,6 +182,9 @@ def mock_cognito_create_user_add_user_to_group_fails(admin_user, create_user_arg
             "GroupName": group_name,
         },
     )
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_disable_user(stubber, admin_user["email"])
+
     stubber.activate()
     # override boto.client to return the mock client
     boto3.client = lambda service, region_name=None: client

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -80,6 +80,110 @@ def mock_cognito_create_user(admin_user, create_user_arguments):
     return stubber
 
 
+def mock_cognito_create_user_set_mfa_fails(admin_user, create_user_arguments):
+    _keep_it_real()
+    client = boto3.real_client("cognito-idp")
+
+    group_name = admin_user["group"]["value"]
+
+    stubber = Stubber(client)
+
+    # Add responses
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_create_user(stubber, admin_user, create_user_arguments)
+    stub_response_cognito_list_user_pools(stubber)
+    # Replace admin_set_user_mfa_preference response with ClientError
+    # stub_response_cognito_admin_set_user_mfa_preference(stubber, admin_user["email"])
+    stubber.add_client_error(
+        "admin_set_user_mfa_preference",
+        expected_params={
+            "SMSMfaSettings": {"Enabled": True, "PreferredMfa": True},
+            "UserPoolId": MOCK_COGNITO_USER_POOL_ID,
+            "Username": admin_user["email"],
+        },
+    )
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_set_user_settings(stubber, admin_user["email"])
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_add_user_to_group(
+        stubber, admin_user["email"], group_name
+    )
+
+    stubber.activate()
+    # override boto.client to return the mock client
+    boto3.client = lambda service, region_name=None: client
+    return stubber
+
+
+def mock_cognito_create_user_set_user_settings_fails(admin_user, create_user_arguments):
+    _keep_it_real()
+    client = boto3.real_client("cognito-idp")
+
+    group_name = admin_user["group"]["value"]
+
+    stubber = Stubber(client)
+
+    # Add responses
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_create_user(stubber, admin_user, create_user_arguments)
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_set_user_mfa_preference(stubber, admin_user["email"])
+    stub_response_cognito_list_user_pools(stubber)
+    # stub_response_cognito_admin_set_user_settings(stubber, admin_user["email"])
+    stubber.add_client_error(
+        "admin_set_user_settings",
+        expected_params={
+            "MFAOptions": [{"DeliveryMedium": "SMS", "AttributeName": "phone_number"}],
+            "UserPoolId": MOCK_COGNITO_USER_POOL_ID,
+            "Username": admin_user["email"],
+        },
+    )
+
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_add_user_to_group(
+        stubber, admin_user["email"], group_name
+    )
+
+    stubber.activate()
+    # override boto.client to return the mock client
+    boto3.client = lambda service, region_name=None: client
+    return stubber
+
+
+def mock_cognito_create_user_add_user_to_group_fails(admin_user, create_user_arguments):
+    _keep_it_real()
+    client = boto3.real_client("cognito-idp")
+
+    group_name = admin_user["group"]["value"]
+
+    stubber = Stubber(client)
+
+    # Add responses
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_create_user(stubber, admin_user, create_user_arguments)
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_set_user_mfa_preference(stubber, admin_user["email"])
+    stub_response_cognito_list_user_pools(stubber)
+    stub_response_cognito_admin_set_user_settings(stubber, admin_user["email"])
+    stub_response_cognito_list_user_pools(stubber)
+
+    # stub_response_cognito_admin_add_user_to_group(
+    #     stubber, admin_user["email"], group_name
+    # )
+    stubber.add_client_error(
+        "admin_add_user_to_group",
+        expected_params={
+            "UserPoolId": MOCK_COGNITO_USER_POOL_ID,
+            "Username": admin_user["email"],
+            "GroupName": group_name,
+        },
+    )
+    stubber.activate()
+    # override boto.client to return the mock client
+    boto3.client = lambda service, region_name=None: client
+    return stubber
+
+
 def mock_cognito_list_pools(env="development"):
     _keep_it_real()
     client = boto3.real_client("cognito-idp")

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -273,3 +273,66 @@ def test_reinvite_create_user_fails(
     with stubber:
         assert not valid_user.reinvite()
         stubber.deactivate()
+
+
+@pytest.mark.usefixtures("admin_user", "create_user_arguments")
+def test_user_create_fails_if_admin_set_mfa_preference_fails(
+    admin_user, create_user_arguments
+):
+    group_name = admin_user["group"]["value"]
+    stubber = stubs.mock_cognito_create_user_set_mfa_fails(
+        admin_user, create_user_arguments
+    )
+
+    with stubber:
+        test_user = User(admin_user["email"])
+        assert not test_user.create(
+            admin_user["name"],
+            admin_user["phone_number"],
+            admin_user["custom:paths"],
+            admin_user["custom:is_la"],
+            group_name,
+        )
+        stubber.deactivate()
+
+
+@pytest.mark.usefixtures("admin_user", "create_user_arguments")
+def test_user_create_fails_if_admin_set_user_settings_fails(
+    admin_user, create_user_arguments
+):
+    group_name = admin_user["group"]["value"]
+    stubber = stubs.mock_cognito_create_user_set_user_settings_fails(
+        admin_user, create_user_arguments
+    )
+
+    with stubber:
+        test_user = User(admin_user["email"])
+        assert not test_user.create(
+            admin_user["name"],
+            admin_user["phone_number"],
+            admin_user["custom:paths"],
+            admin_user["custom:is_la"],
+            group_name,
+        )
+        stubber.deactivate()
+
+
+@pytest.mark.usefixtures("admin_user", "create_user_arguments")
+def test_user_create_fails_if_admin_add_user_to_group_fails(
+    admin_user, create_user_arguments
+):
+    group_name = admin_user["group"]["value"]
+    stubber = stubs.mock_cognito_create_user_add_user_to_group_fails(
+        admin_user, create_user_arguments
+    )
+
+    with stubber:
+        test_user = User(admin_user["email"])
+        assert not test_user.create(
+            admin_user["name"],
+            admin_user["phone_number"],
+            admin_user["custom:paths"],
+            admin_user["custom:is_la"],
+            group_name,
+        )
+        stubber.deactivate()

--- a/user.py
+++ b/user.py
@@ -105,6 +105,13 @@ class User:
 
         if error:
             config.set_session_var("error_message", error)
+            LOG.error(
+                {
+                    "message": "User operation failed",
+                    "action": "user.create",
+                    "status": steps,
+                }
+            )
         # Return True only if all settings were successfully set
         return all(steps.values())
 
@@ -205,6 +212,13 @@ class User:
 
         if error:
             config.set_session_var("error_message", error)
+            LOG.error(
+                {
+                    "message": "User operation failed",
+                    "action": "user.update",
+                    "status": steps,
+                }
+            )
 
         # Return True if valid and updated
         return all(steps.values())

--- a/user.py
+++ b/user.py
@@ -253,7 +253,7 @@ class User:
 
         # All non-admin users should have a non-empty path in custom:paths
         if "admin" not in group_name and paths_semicolon_separated == "":
-            LOG.info(
+            LOG.error(
                 {
                     "user": self.email_address,
                     "group": group_name,
@@ -276,7 +276,7 @@ class User:
                 user_is_local_authority = is_la == "1"
                 path_is_local_authority = path.startswith(la_path)
                 if user_is_local_authority != path_is_local_authority:
-                    LOG.info(
+                    LOG.error(
                         {
                             "user": self.email_address,
                             "group": group_name,

--- a/user.py
+++ b/user.py
@@ -103,6 +103,13 @@ class User:
         else:
             error = "Failed to create user."
 
+        if steps.get("created") and not all(steps.values()):
+            # If the user was created successfully
+            # but the group or SMS 2FA operations fail
+            # the user should be disabled.
+            if steps.get("created"):
+                cognito.disable_user(self.email_address)
+
         if error:
             config.set_session_var("error_message", error)
             LOG.error(
@@ -112,6 +119,7 @@ class User:
                     "status": steps,
                 }
             )
+
         # Return True only if all settings were successfully set
         return all(steps.values())
 

--- a/user.py
+++ b/user.py
@@ -90,6 +90,7 @@ class User:
             steps["paths_valid"] = False
             error = "The granted access permissions are not valid."
 
+        # Only attempt create if all previous steps passed
         if all(steps.values()):
             steps["created"] = cognito.create_user(
                 name, self.email_address, phone_number, is_la, custom_paths

--- a/user.py
+++ b/user.py
@@ -136,7 +136,7 @@ class User:
 
     def update(self, name, phone_number, custom_paths, is_la, group):
 
-        steps = {"valid": True}
+        steps = {"updated": False}
         error = None
 
         # Check user exists


### PR DESCRIPTION
At the moment the `/admin/user/error` route just says "Error". 

Remove multiple return statements and replace with `all()`
Change the `user.create` and `user.update` methods to record an error message into the session. 
Present the default `error.html` template which renders the session error message. 
Change the handling of `user.create` so that if any of the subsequent operations to set the SMS 2FA or the group fail the user is disabled. 
Add tests of user.create returning a ClientError from the 3 subsequent operations. 
Log errors with the status of all operations from create and update to aid debugging. 