### PR TITLE
Use config to serve app_environment.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-05-27T13:29:39Z",
+  "generated_at": "2020-06-05T09:44:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -65,7 +65,7 @@
         "hashed_secret": "dea742e166979027ae70b28e0a9006fb1010e760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 236,
+        "line_number": 243,
         "type": "Secret Keyword"
       }
     ]

--- a/README.md
+++ b/README.md
@@ -144,3 +144,17 @@ eval $(gds aws security-test -e); make e2e
 The tests are automatically run against staging in the 
 pipeline but can be run manually by assuming a 
 different role and setting different credentials. 
+
+## Configuration
+
+The config.py module provides an interface to the  
+standard Flask app.config. The reason for this is 
+by setting this up in config functions in modules 
+that don't have access to the flask app object can 
+get and set config settings without having to 
+import app.
+
+A number of settings are passed into the app as 
+environment variables and these are loaded into 
+app.config as the first step of the local run module 
+and the lambda lambda_handler module.   

--- a/README.md
+++ b/README.md
@@ -148,11 +148,12 @@ different role and setting different credentials.
 ## Configuration
 
 The config.py module provides an interface to the  
-standard Flask app.config. The reason for this is 
-by setting this up in config functions in modules 
-that don't have access to the flask app object can 
-get and set config settings without having to 
-import app.
+standard Flask app.config. The interface makes it 
+easier and more effective to set and get 
+configuration values. We retrieve configuration 
+settings without having to import the app every 
+time by using config functions in modules which 
+don't have access to the flask app object.
 
 A number of settings are passed into the app as 
 environment variables and these are loaded into 

--- a/config.py
+++ b/config.py
@@ -12,7 +12,7 @@ CONFIG = {}
 
 def setup_talisman(app):
     csp = {"default-src": ["'self'", "https://*.s3.amazonaws.com"]}
-    is_https = app.app_environment != "testing"
+    is_https = get("app_environment", "testing") != "testing"
     log_message = (
         "loading Talisman with HTTPS"
         if is_https

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -157,7 +157,7 @@ def render_template_custom(app, template, hide_logout=False, **args):
 
     page_title = config.get("page_title", "Data Transfer")
     if is_development():
-        page_title = "{} - {}".format(app.app_environment.upper(), page_title)
+        page_title = "{} - {}".format(config.get("app_environment").upper(), page_title)
     args["title"] = page_title
 
     return render_template(template, **args)

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -32,7 +32,7 @@ def admin(event, context):
 
 
 def run(event, context):
-    config.setup_talisman(app)
     config.load_environment(app)
+    config.setup_talisman(app)
     config.load_ssm_parameters(app)
     return serverless_wsgi.handle_request(app, event, context)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import json
-import os
 import re
 from collections import defaultdict
 from datetime import datetime
@@ -29,7 +28,6 @@ from logger import LOG
 from user import User
 
 app = Flask(__name__)
-app.app_environment = os.getenv("APP_ENVIRONMENT", "testing")
 app.logger = LOG
 
 
@@ -63,7 +61,7 @@ def exchange_code_for_session_user(code, code_verifier=None) -> dict:
     client = boto3.client("cognito-idp")
     cognito_user = client.get_user(AccessToken=oauth_response_body["access_token"])
 
-    is_not_production = app.app_environment != "production"
+    is_not_production = config.get("app_environment") != "production"
     # only get these attributes if the MFA is present
     if is_not_production or is_mfa_configured(cognito_user):
         session["attributes"] = cognito_user["UserAttributes"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ env =
     BUCKET_NAME=test_bucket
     BUCKET_MAIN_PREFIX=web-app-prod-data
     ADMIN=true
+    APP_ENVIRONMENT=testing

--- a/run.py
+++ b/run.py
@@ -9,8 +9,8 @@ def run():
     """
     Run a local server
     """
-    config.setup_talisman(app)
     config.load_environment(app)
+    config.setup_talisman(app)
     ssm_loaded = config.load_ssm_parameters(app)
     if ssm_loaded:
         app.run(host="0.0.0.0", port=os.getenv("PORT", "8000"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,17 +9,17 @@ import config
 
 def test_setup_talisman():
     app = Flask(__name__)
-    app.app_environment = "testing"
+    config.set("app_environment", "testing")
     talisman = config.setup_talisman(app)
     assert not talisman.force_https
 
     app = Flask(__name__)
-    app.app_environment = "staging"
+    config.set("app_environment", "staging")
     talisman = config.setup_talisman(app)
     assert talisman.force_https
 
     app = Flask(__name__)
-    app.app_environment = "production"
+    config.set("app_environment", "production")
     talisman = config.setup_talisman(app)
     assert talisman.force_https
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,7 @@ import pytest
 import requests_mock
 
 import stubs
+import config
 from main import (
     app,
     categorise_file,
@@ -237,7 +238,7 @@ def test_auth_flow_with_no_mfa_user(
     domain = "test.cognito.domain.com"
     token_endpoint_url = f"https://{domain}/oauth2/token"
     app.config["cognito_domain"] = domain
-    app.app_environment = "production"
+    config.set("app_environment", "production")
     app.config["client_id"] = "123456"
     app.config["client_secret"] = "987654"
     app.config["redirect_host"] = "test.domain.com"

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 import stubs
+import config
 from user import User
 
 
@@ -85,6 +86,7 @@ def test_sanitise_name(valid_user):
 def test_update_returns_false_if_user_not_found(valid_user):
     email = valid_user.email_address
     stubber = stubs.mock_user_not_found(email)
+    config.set("app_environment", "testing")
     with stubber:
         assert not valid_user.update(
             "new name", "+441234567890", "web-app-prod-data", "0", "standard-upload"


### PR DESCRIPTION
Replace references to app.app_environment with config.get()
Move load_environment ahead of setup_talisman in run and lambda_handler
Fix broken tests