### PR TITLE
Remove copy of hub.csv from make build target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ copy_dir:
 	set -e
 	echo "⏳ copying..."
 	cp *.py .target
-	cp hub.csv .target
 	cp *.yml .target
 	cp *.txt .target
 	cp -R assets .target


### PR DESCRIPTION
The hub.csv file has been moved to covid-engineering.