### PR TITLE
Set BUCKET_MAIN_PREFIX env var in run.py based on environment run argument.

### DIFF
--- a/config.py
+++ b/config.py
@@ -88,6 +88,7 @@ def setup_local_environment(
 
     if environment:
         os.environ["APP_ENVIRONMENT"] = environment
+        os.environ["BUCKET_MAIN_PREFIX"] = f"web-app-{environment}-data"
         if environment == "testing":
             os.environ["BUCKET_NAME"] = "backend-consumer-service-test"
 


### PR DESCRIPTION
This enables the admin app to be run offline for multiple environments.

Previously this was working because the S3 config used the prefix `web-app-prod-data` in all environments.