### PR TITLE
Add an upload history section to the upload page.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-06-05T09:44:56Z",
+  "generated_at": "2020-06-11T07:57:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -65,7 +65,7 @@
         "hashed_secret": "dea742e166979027ae70b28e0a9006fb1010e760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 243,
+        "line_number": 255,
         "type": "Secret Keyword"
       }
     ]

--- a/behave/features/11.user_upload_history.feature
+++ b/behave/features/11.user_upload_history.feature
@@ -1,0 +1,12 @@
+# COVID19 - User can see their upload file history
+Feature: COVID19 Data Transfer - User upload file history
+    @user
+    Scenario: user can see upload file history
+        Given credentials for the "standard-upload" group
+        When you login with these credentials
+        When I click on button "Upload"
+        Then wait "5" seconds
+        Then the content of element with selector ".covid-transfer-page-title" contains "COVID-19 Data Transfer"
+        Then the content of element with selector "#main-content .covid-transfer-username" contains username
+        Then the content of element with selector "#main-content .covid-transfer-upload-section" contains "other/gds/MOCK_DATA.csv"
+

--- a/templates/components/upload-history.html
+++ b/templates/components/upload-history.html
@@ -1,0 +1,30 @@
+{% if upload_history|length > 0 %}
+<section class="covid-transfer-upload-section">
+    <h2 class="govuk-heading-m">Upload history</h2>
+    <div>
+      <ul class="app-task-list govuk-list">
+        {% for file_date in upload_history.by_date %}
+        {% set date_files = upload_history.by_date[file_date] %}
+        <li>
+          <h3 class="govuk-heading-m app-task-list__section">
+            {{ file_date }}
+          </h3>
+          <ul class="app-task-list__items govuk-list">
+            {% for file in date_files %}
+            <li class="app-task-list__item">
+
+              <span class="app-task-list__task-name">
+                <span>{{ file.category }} ({{ file.size|filesizeformat }})</span><br/>
+                <p>
+                  {{ file.key | s3_remove_root_path }}
+                </p>
+              </span>
+            </li>
+            {% endfor %}
+          </ul>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+</section>
+{% endif %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -111,6 +111,8 @@
 
   {% include "components/upload-template.html" %}
 
+  {% include "components/upload-history.html" %}
+
 {% endblock %}
 {% block scriptblock %}
   <script src="/js/s3upload.js?update=20200521-1424"></script>


### PR DESCRIPTION
Show previously uploaded files on the upload page.
Hide the upload metadata files.
Add a behave scenario and unit test stubbing to check these are rendered correctly.

This work is based on feedback from users.