### PR TITLE
Deploy to dev four

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,10 @@ s3paths:
 	bash s3paths.sh
 
 run: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py main testing
+	docker-compose run --service-ports chrome-driver python3 run.py main dev-four
 
 run_test: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py main testing
+	docker-compose run --service-ports chrome-driver python3 run.py main dev-four
 
 run_staging: rebuild
 	docker-compose run --service-ports chrome-driver python3 run.py main staging
@@ -76,7 +76,7 @@ run_prod: rebuild
 	docker-compose run --service-ports chrome-driver python3 run.py main production
 
 admin_test: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py admin testing
+	docker-compose run --service-ports chrome-driver python3 run.py admin dev-four
 
 admin_staging: rebuild
 	docker-compose run --service-ports chrome-driver python3 run.py admin staging
@@ -90,7 +90,7 @@ zip: build
 	echo "✔️ zip file built!"
 
 e2e: rebuild
-	docker-compose run chrome-driver bash -c "python3 run.py admin testing & cd behave && behave"
+	docker-compose run chrome-driver bash -c "python3 run.py admin dev-four & cd behave && behave"
 
 concourse_e2e_paas:
 	cd behave && behave --tags='@user'
@@ -101,4 +101,4 @@ concourse_e2e_lambda:
 concourse_e2e: concourse_e2e_paas
 
 e2e_scenario: rebuild
-	docker-compose run chrome-driver bash -c "python3 run.py admin testing & cd behave && behave -n \"$(scenario)\""
+	docker-compose run chrome-driver bash -c "python3 run.py admin dev-four & cd behave && behave -n \"$(scenario)\""

--- a/behave/features/steps/user_routes.py
+++ b/behave/features/steps/user_routes.py
@@ -10,7 +10,7 @@ def get_plus_string(group_name):
     # To keep things short I've truncated the stage name
     # in the plus string from the longer name used in the
     # ENVIRONMENT env var
-    stages = {"testing": "test", "staging": "stage"}
+    stages = {"testing": "test", "staging": "stage", "dev-four": "test"}
     env = stages[os.environ.get("ENVIRONMENT", "testing")]
 
     # for a stupid reason I created all the test users

--- a/config.py
+++ b/config.py
@@ -89,8 +89,6 @@ def setup_local_environment(
     if environment:
         os.environ["APP_ENVIRONMENT"] = environment
         os.environ["BUCKET_MAIN_PREFIX"] = f"web-app-{environment}-data"
-        if environment == "testing":
-            os.environ["BUCKET_NAME"] = "backend-consumer-service-test"
 
     os.environ["PAGE_TITLE"] = "LOCAL COVID-19 Data Transfer"
     os.environ["FLASK_ENV"] = "development"
@@ -179,8 +177,8 @@ def get_cognito_pool_name():
     pool_name_prefix = "corona-cognito-pool"
     if environment == "production":
         suffix = "prod"
-    elif environment == "testing":
-        suffix = "development"
+    elif environment in ("dev-four", "testing"):
+        suffix = "dev-four"
     else:
         suffix = environment
 

--- a/config.py
+++ b/config.py
@@ -177,7 +177,7 @@ def get_cognito_pool_name():
     pool_name_prefix = "corona-cognito-pool"
     if environment == "production":
         suffix = "prod"
-    elif environment in ("dev-four", "testing"):
+    elif environment == "testing":
         suffix = "dev-four"
     else:
         suffix = environment
@@ -226,6 +226,7 @@ def list_pools():
             {key.lower(): value for key, value in pool.items()}
             for pool in response["UserPools"]
         ]
+    LOG.debug(pool_list)
     return pool_list
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - E2E_STAGING_PASSWORD=$E2E_STAGING_PASSWORD
       - LOG_LEVEL=$LOG_LEVEL
       - PYTHONIOENCODING=UTF-8
-      - APP_ENVIRONMENT=testing
+      - APP_ENVIRONMENT=dev-four
+      - BUCKET_NAME=gds-ons-covid-19-query-results-dev-four
     ports:
       - "8000:8000"

--- a/run.py
+++ b/run.py
@@ -42,7 +42,7 @@ def handle_args(is_admin, env_load):
 
     if sys.argv[0] == "run.py":
         cont = "y"
-        if env_load != "testing":
+        if env_load not in ("testing", "dev-four"):
             try:
                 cont = input(
                     "Not {}testing{}; do you want to continue? (Y/n) ".format(

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -4,6 +4,8 @@ from datetime import datetime
 import boto3
 from botocore.stub import Stubber
 
+from logger import LOG
+
 MOCK_COGNITO_USER_POOL_ID = "eu-west-2_poolid"
 
 
@@ -194,7 +196,7 @@ def mock_cognito_create_user_add_user_to_group_fails(admin_user, create_user_arg
     return stubber
 
 
-def mock_cognito_list_pools(env="development"):
+def mock_cognito_list_pools(env="dev-four"):
     _keep_it_real()
     client = boto3.real_client("cognito-idp")
 
@@ -693,12 +695,13 @@ def stub_response_s3_list_upload_objects_page_2(stubber, bucket_name, prefix):
 
 
 # Client: cognito-idp
-def stub_response_cognito_list_user_pools(stubber, env="development"):
+def stub_response_cognito_list_user_pools(stubber, env="dev-four"):
     mock_list_user_pools = {
         "UserPools": [
             {"Id": MOCK_COGNITO_USER_POOL_ID, "Name": f"corona-cognito-pool-{env}"}
         ]
     }
+    LOG.debug(mock_list_user_pools)
     stubber.add_response("list_user_pools", mock_list_user_pools, {"MaxResults": 10})
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,4 +104,4 @@ def test_get_cognito_pool_name():
     config.set("app_environment", "staging")
     assert config.get_cognito_pool_name() == "corona-cognito-pool-staging"
     config.set("app_environment", "testing")
-    assert config.get_cognito_pool_name() == "corona-cognito-pool-development"
+    assert config.get_cognito_pool_name() == "corona-cognito-pool-dev-four"

--- a/user.py
+++ b/user.py
@@ -193,7 +193,7 @@ class User:
                 phone_number is not None,
                 custom_paths is not None,
                 is_la is not None,
-                group is not None
+                group is not None,
             ]
         )
         if not steps.get("inputs_valid"):


### PR DESCRIPTION
The testing cognito user-pool and s3 bucket are now in the dev-four
account and suffixed with dev-four which means these are the
default cognito pool and s3 bucket for running the code and e2e
tests in local (offline) environments.