### PR TITLE
Refactor cognito to load pool_id from SSM.

### DIFF
--- a/cognito.py
+++ b/cognito.py
@@ -77,7 +77,7 @@ def create_user(name, email_address, phone_number, is_la, custom_paths):
     client = get_boto3_client()
     try:
         response = client.admin_create_user(
-            UserPoolId=config.env_pool_id(),
+            UserPoolId=config.get("cognito_pool_id"),
             Username=email_address,
             UserAttributes=[
                 {"Name": "name", "Value": name},
@@ -101,7 +101,9 @@ def update_user(email, attributes):
     cognito_client = get_boto3_client()
     try:
         response = cognito_client.admin_update_user_attributes(
-            UserPoolId=config.env_pool_id(), Username=email, UserAttributes=attributes
+            UserPoolId=config.get("cognito_pool_id"),
+            Username=email,
+            UserAttributes=attributes,
         )
     except (ClientError, ParamValidationError) as error:
         LOG.error(error)
@@ -113,7 +115,7 @@ def delete_user(email):
     cognito_client = get_boto3_client()
     try:
         response = cognito_client.admin_delete_user(
-            UserPoolId=config.env_pool_id(), Username=email
+            UserPoolId=config.get("cognito_pool_id"), Username=email
         )
     except CLIENT_EXCEPTIONS as error:
         LOG.error(error)
@@ -125,7 +127,7 @@ def disable_user(email):
     cognito_client = get_boto3_client()
     try:
         response = cognito_client.admin_disable_user(
-            UserPoolId=config.env_pool_id(), Username=email
+            UserPoolId=config.get("cognito_pool_id"), Username=email
         )
     except CLIENT_EXCEPTIONS as error:
         LOG.error(error)
@@ -137,7 +139,7 @@ def enable_user(email):
     cognito_client = get_boto3_client()
     try:
         response = cognito_client.admin_enable_user(
-            UserPoolId=config.env_pool_id(), Username=email
+            UserPoolId=config.get("cognito_pool_id"), Username=email
         )
     except CLIENT_EXCEPTIONS as error:
         LOG.error(error)
@@ -149,7 +151,7 @@ def set_user_settings(email):
     client = get_boto3_client()
     try:
         response = client.admin_set_user_settings(
-            UserPoolId=config.env_pool_id(),
+            UserPoolId=config.get("cognito_pool_id"),
             Username=email,
             MFAOptions=[{"DeliveryMedium": "SMS", "AttributeName": "phone_number"}],
         )
@@ -163,7 +165,7 @@ def set_mfa_preferences(email):
     cognito_client = get_boto3_client()
     try:
         response = cognito_client.admin_set_user_mfa_preference(
-            UserPoolId=config.env_pool_id(),
+            UserPoolId=config.get("cognito_pool_id"),
             Username=email,
             SMSMfaSettings={"Enabled": True, "PreferredMfa": True},
         )
@@ -182,7 +184,9 @@ def add_to_group(email, group_name):
     cognito_client = get_boto3_client()
     try:
         response = cognito_client.admin_add_user_to_group(
-            UserPoolId=config.env_pool_id(), Username=email, GroupName=group_name
+            UserPoolId=config.get("cognito_pool_id"),
+            Username=email,
+            GroupName=group_name,
         )
     except CLIENT_EXCEPTIONS as error:
         LOG.error(error)
@@ -194,7 +198,9 @@ def remove_from_group(email, group_name):
     cognito_client = get_boto3_client()
     try:
         response = cognito_client.admin_remove_user_from_group(
-            UserPoolId=config.env_pool_id(), Username=email, GroupName=group_name
+            UserPoolId=config.get("cognito_pool_id"),
+            Username=email,
+            GroupName=group_name,
         )
     except CLIENT_EXCEPTIONS as error:
         LOG.error(error)
@@ -206,7 +212,7 @@ def get_user(email):
     cognito_client = get_boto3_client()
     try:
         response = cognito_client.admin_get_user(
-            UserPoolId=config.env_pool_id(), Username=email
+            UserPoolId=config.get("cognito_pool_id"), Username=email
         )
     except CLIENT_EXCEPTIONS as error:
         LOG.error(error)
@@ -218,7 +224,7 @@ def list_groups_for_user(email):
     cognito_client = get_boto3_client()
     try:
         response = cognito_client.admin_list_groups_for_user(
-            UserPoolId=config.env_pool_id(), Username=email
+            UserPoolId=config.get("cognito_pool_id"), Username=email
         )
     except CLIENT_EXCEPTIONS as error:
         LOG.error(error)

--- a/conftest.py
+++ b/conftest.py
@@ -361,9 +361,8 @@ def test_list_object_file():
 @pytest.fixture()
 def test_ssm_parameters():
     return {
-        "/cognito/client_id": "abc123",
-        "/cognito/client_secret": "def456",  # pragma: allowlist secret
-        "/cognito/domain": "example.com",
+        "/cognito/pool/name": "cognito_pool_name",
+        "/cognito/pool/id": "eu-west-2_poolid",
         "/s3/bucket_name": "my_bucket",
         "/flask/secret_key": "my_secret_key",
     }

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -33,6 +33,5 @@ def admin(event, context):
 
 def run(event, context):
     config.load_environment(app)
-    config.setup_talisman(app)
-    config.load_ssm_parameters(app)
+    config.load_settings(app)
     return serverless_wsgi.handle_request(app, event, context)

--- a/run.py
+++ b/run.py
@@ -10,9 +10,8 @@ def run():
     Run a local server
     """
     config.load_environment(app)
-    config.setup_talisman(app)
-    ssm_loaded = config.load_ssm_parameters(app)
-    if ssm_loaded:
+    settings_loaded = config.load_settings(app)
+    if settings_loaded:
         app.run(host="0.0.0.0", port=os.getenv("PORT", "8000"))
     else:
         green_char = "\033[92m"

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -49,7 +49,6 @@ def mock_cognito_auth_flow(token, test_user):
 
     # Add responses
     stub_response_cognito_get_user(stubber, token, test_user)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_list_groups_for_user(stubber, test_user["Username"])
 
     stubber.activate()
@@ -68,13 +67,9 @@ def mock_cognito_create_user(admin_user, create_user_arguments):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_create_user(stubber, admin_user, create_user_arguments)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_mfa_preference(stubber, admin_user["email"])
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_settings(stubber, admin_user["email"])
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_add_user_to_group(
         stubber, admin_user["email"], group_name
     )
@@ -94,9 +89,7 @@ def mock_cognito_create_user_set_mfa_fails(admin_user, create_user_arguments):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_create_user(stubber, admin_user, create_user_arguments)
-    stub_response_cognito_list_user_pools(stubber)
     # Replace admin_set_user_mfa_preference response with ClientError
     # stub_response_cognito_admin_set_user_mfa_preference(stubber, admin_user["email"])
     stubber.add_client_error(
@@ -107,13 +100,10 @@ def mock_cognito_create_user_set_mfa_fails(admin_user, create_user_arguments):
             "Username": admin_user["email"],
         },
     )
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_settings(stubber, admin_user["email"])
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_add_user_to_group(
         stubber, admin_user["email"], group_name
     )
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_disable_user(stubber, admin_user["email"])
 
     stubber.activate()
@@ -131,11 +121,8 @@ def mock_cognito_create_user_set_user_settings_fails(admin_user, create_user_arg
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_create_user(stubber, admin_user, create_user_arguments)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_mfa_preference(stubber, admin_user["email"])
-    stub_response_cognito_list_user_pools(stubber)
     # stub_response_cognito_admin_set_user_settings(stubber, admin_user["email"])
     stubber.add_client_error(
         "admin_set_user_settings",
@@ -146,11 +133,9 @@ def mock_cognito_create_user_set_user_settings_fails(admin_user, create_user_arg
         },
     )
 
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_add_user_to_group(
         stubber, admin_user["email"], group_name
     )
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_disable_user(stubber, admin_user["email"])
 
     stubber.activate()
@@ -168,13 +153,9 @@ def mock_cognito_create_user_add_user_to_group_fails(admin_user, create_user_arg
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_create_user(stubber, admin_user, create_user_arguments)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_mfa_preference(stubber, admin_user["email"])
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_settings(stubber, admin_user["email"])
-    stub_response_cognito_list_user_pools(stubber)
 
     # stub_response_cognito_admin_add_user_to_group(
     #     stubber, admin_user["email"], group_name
@@ -187,7 +168,6 @@ def mock_cognito_create_user_add_user_to_group_fails(admin_user, create_user_arg
             "GroupName": group_name,
         },
     )
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_disable_user(stubber, admin_user["email"])
 
     stubber.activate()
@@ -223,7 +203,6 @@ def mock_cognito_admin_create_user(user, arguments):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_create_user(stubber, user, params_admin_create_user)
 
     stubber.activate()
@@ -239,7 +218,6 @@ def mock_cognito_admin_update_user_attributes(user, attributes):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_update_user_attributes(
         stubber, user["email"], attributes
     )
@@ -257,7 +235,6 @@ def mock_cognito_admin_delete_user(email):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_delete_user(stubber, email)
 
     stubber.activate()
@@ -273,7 +250,6 @@ def mock_cognito_admin_disable_user(email):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_disable_user(stubber, email)
 
     stubber.activate()
@@ -289,7 +265,6 @@ def mock_cognito_admin_enable_user(email):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_enable_user(stubber, email)
 
     stubber.activate()
@@ -305,7 +280,6 @@ def mock_cognito_admin_set_user_settings(email):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_settings(stubber, email)
 
     stubber.activate()
@@ -320,7 +294,6 @@ def mock_cognito_admin_set_user_mfa_preference(email):
 
     stubber = Stubber(client)
 
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_mfa_preference(stubber, email)
 
     stubber.activate()
@@ -336,7 +309,6 @@ def mock_cognito_admin_add_user_to_group(email, group_name):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_add_user_to_group(stubber, email, group_name)
 
     stubber.activate()
@@ -352,7 +324,6 @@ def mock_cognito_admin_remove_user_from_group(email, group_name):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_remove_user_from_group(stubber, email, group_name)
 
     stubber.activate()
@@ -368,7 +339,6 @@ def mock_cognito_admin_get_user(email, admin_get_user):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_get_user(stubber, email, admin_get_user)
 
     stubber.activate()
@@ -384,7 +354,6 @@ def mock_cognito_admin_list_groups_for_user(admin_user):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_list_groups_for_user(stubber, admin_user["email"])
 
     stubber.activate()
@@ -401,9 +370,7 @@ def mock_user_get_details(email, admin_get_user):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_get_user(stubber, email, admin_get_user)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_list_groups_for_user(stubber, email)
 
     stubber.activate()
@@ -419,7 +386,6 @@ def mock_user_not_found(email):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stubber.add_client_error(
         "admin_get_user",
         expected_params={"UserPoolId": MOCK_COGNITO_USER_POOL_ID, "Username": email},
@@ -438,11 +404,8 @@ def mock_user_update(email, admin_get_user, attributes):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_get_user(stubber, email, admin_get_user)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_list_groups_for_user(stubber, email)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_update_user_attributes(stubber, email, attributes)
 
     stubber.activate()
@@ -461,23 +424,16 @@ def mock_user_reinvite(admin_user, admin_get_user, create_user_arguments):
 
     # Add responses
     # get user
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_get_user(stubber, admin_user["email"], admin_get_user)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_list_groups_for_user(stubber, admin_user["email"])
 
     # delete user
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_delete_user(stubber, admin_user["email"])
 
     # create user
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_create_user(stubber, admin_user, create_user_arguments)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_mfa_preference(stubber, admin_user["email"])
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_set_user_settings(stubber, admin_user["email"])
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_add_user_to_group(
         stubber, admin_user["email"], group_name
     )
@@ -496,13 +452,10 @@ def mock_delete_user_failure(admin_user, admin_get_user):
 
     # Add responses
     # get user
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_get_user(stubber, admin_user["email"], admin_get_user)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_list_groups_for_user(stubber, admin_user["email"])
 
     # delete user
-    stub_response_cognito_list_user_pools(stubber)
     stubber.add_client_error(
         "admin_delete_user",
         expected_params={
@@ -525,17 +478,13 @@ def mock_create_user_failure(admin_user, admin_get_user, create_user_arguments):
 
     # Add responses
     # get user
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_get_user(stubber, admin_user["email"], admin_get_user)
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_list_groups_for_user(stubber, admin_user["email"])
 
     # delete user
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_admin_delete_user(stubber, admin_user["email"])
 
     # create user
-    stub_response_cognito_list_user_pools(stubber)
     stubber.add_client_error(
         "admin_create_user", expected_params=create_user_arguments,
     )
@@ -553,7 +502,6 @@ def mock_config_set_app_settings(parameters):
     stubber = Stubber(client)
 
     # Add responses
-    stub_response_cognito_list_user_pools(stubber)
     stub_response_cognito_list_user_pool_clients(stubber, parameters)
     stub_response_cognito_describe_user_pool_client(stubber, parameters)
     stub_response_cognito_describe_user_pool(stubber, parameters)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -12,6 +12,7 @@ from admin import (
 )
 from helpers import body_has_element_with_attributes, flatten_html
 from main import app
+import config
 
 
 @pytest.mark.usefixtures("admin_user", "user_confirm_form")
@@ -133,6 +134,7 @@ def test_route_admin_user_query(
     with test_client.session_transaction() as client_session:
         client_session.update(test_admin_session)
 
+    config.set("cognito_pool_id", stubs.MOCK_COGNITO_USER_POOL_ID)
     email = admin_user["email"]
     stubber = stubs.mock_user_get_details(email, admin_get_user)
     with stubber:


### PR DESCRIPTION
ON HOLD: until https://github.com/alphagov/covid-engineering/pull/441 is merged. 

Add config to get cognito pool name and id from SSM.
Remove unused cognito client_id/secret/domain SSM config -
these are retrieved directly from cognito via boto3.
Refactor ssm and cognito into load_settings function.
Remove redundant code
Remove multiple calls to list_user_pools from stubbing.
Fix tests.