### PR TITLE
Simplify running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,25 +64,7 @@ s3paths:
 	bash s3paths.sh
 
 run: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py main dev-four
-
-run_test: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py main dev-four
-
-run_staging: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py main staging
-
-run_prod: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py main production
-
-admin_test: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py admin dev-four
-
-admin_staging: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py admin staging
-
-admin_prod: rebuild
-	docker-compose run --service-ports chrome-driver python3 run.py admin production
+	docker-compose run --service-ports chrome-driver python3 run.py
 
 zip: build
 	mkdir -p builds
@@ -90,7 +72,7 @@ zip: build
 	echo "✔️ zip file built!"
 
 e2e: rebuild
-	docker-compose run chrome-driver bash -c "python3 run.py admin dev-four & cd behave && behave"
+	docker-compose run chrome-driver bash -c "python3 run.py & cd behave && behave"
 
 concourse_e2e_paas:
 	cd behave && behave --tags='@user'
@@ -101,4 +83,4 @@ concourse_e2e_lambda:
 concourse_e2e: concourse_e2e_paas
 
 e2e_scenario: rebuild
-	docker-compose run chrome-driver bash -c "python3 run.py admin dev-four & cd behave && behave -n \"$(scenario)\""
+	docker-compose run chrome-driver bash -c "python3 run.py & cd behave && behave -n \"$(scenario)\""

--- a/behave/features/steps/user_routes.py
+++ b/behave/features/steps/user_routes.py
@@ -10,7 +10,7 @@ def get_plus_string(group_name):
     # To keep things short I've truncated the stage name
     # in the plus string from the longer name used in the
     # ENVIRONMENT env var
-    stages = {"testing": "test", "staging": "stage", "dev-four": "test"}
+    stages = {"testing": "test", "staging": "stage"}
     env = stages[os.environ.get("ENVIRONMENT", "testing")]
 
     # for a stupid reason I created all the test users

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,8 @@ services:
       - E2E_STAGING_PASSWORD=$E2E_STAGING_PASSWORD
       - LOG_LEVEL=$LOG_LEVEL
       - PYTHONIOENCODING=UTF-8
-      - APP_ENVIRONMENT=dev-four
+      - APP_ENVIRONMENT=testing
       - BUCKET_NAME=gds-ons-covid-19-query-results-dev-four
+      - BUCKET_MAIN_PREFIX=web-app-dev-four-data
     ports:
       - "8000:8000"

--- a/run.py
+++ b/run.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import config
 from main import app
@@ -24,49 +23,6 @@ def run():
         exit()
 
 
-def handle_args(is_admin, env_load):
-
-    green_char = "\033[92m"
-    end_charac = "\033[0m"
-
-    print("-" * 35)
-    print(
-        "Running {0}{2}{1} for: {0}{3}{1}".format(
-            green_char,
-            end_charac,
-            "admin tool" if is_admin else "download tool frontend",
-            env_load,
-        )
-    )
-
-    if sys.argv[0] == "run.py":
-        cont = "y"
-        if env_load not in ("testing", "dev-four"):
-            try:
-                cont = input(
-                    "Not {}testing{}; do you want to continue? (Y/n) ".format(
-                        green_char, end_charac
-                    )
-                ).lower()
-                if cont == "":
-                    cont = "y"
-            except KeyboardInterrupt:
-                print("\nRegistration cancelled.")
-                exit()
-        if cont != "y":
-            exit()
-    print("-" * 35)
-
-
 if __name__ == "__main__":
-
-    if len(sys.argv) == 3:
-        is_admin = sys.argv[1] == "admin"
-        env_load = sys.argv[2]
-    else:
-        is_admin = False
-        env_load = "testing"
-
-    handle_args(is_admin, env_load)
-    config.setup_local_environment(is_admin=is_admin, environment=env_load)
+    config.setup_local_environment(is_admin=True, environment="testing")
     run()

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -176,7 +176,7 @@ def mock_cognito_create_user_add_user_to_group_fails(admin_user, create_user_arg
     return stubber
 
 
-def mock_cognito_list_pools(env="dev-four"):
+def mock_cognito_list_pools(env="testing"):
     _keep_it_real()
     client = boto3.real_client("cognito-idp")
 
@@ -643,7 +643,7 @@ def stub_response_s3_list_upload_objects_page_2(stubber, bucket_name, prefix):
 
 
 # Client: cognito-idp
-def stub_response_cognito_list_user_pools(stubber, env="dev-four"):
+def stub_response_cognito_list_user_pools(stubber, env="testing"):
     mock_list_user_pools = {
         "UserPools": [
             {"Id": MOCK_COGNITO_USER_POOL_ID, "Name": f"corona-cognito-pool-{env}"}


### PR DESCRIPTION
When running locally always expose the `admin` routes.

We've also made a decision that running the app locally but
communicating with a Cognito in staging/production probably isn't a good
idea so we're removing those options. This helps simplify things
further.