### PR TITLE
Catch template errors

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -58,9 +58,7 @@ def admin_user(app):
 
             user_group = return_users_group(user)
 
-            return render_template_custom(
-                app, "admin/user.html", user=user, user_group=user_group, done=done
-            )
+            return render_template_custom("admin/user.html", user=user, user_group=user_group, done=done)
 
     return redirect("/admin/user/not-found")
 
@@ -70,9 +68,7 @@ def admin_user_error(app):
     app.logger.error(f"Server error: {error_message}")
     del session["error_message"]
     return (
-        render_template_custom(
-            app, "error.html", hide_logout=True, error=error_message
-        ),
+        render_template_custom("error.html", hide_logout=True, error=error_message),
         403,
     )
 
@@ -95,14 +91,12 @@ def clear_session(app):
 
 
 def admin_list_users(app):
-    return render_template_custom(app, "admin/list-user.html")
+    return render_template_custom("admin/list-user.html")
 
 
 def admin_main(app):
     clear_session(app)
-    return render_template_custom(
-        app, "admin/index.html", can_create_users=user_has_a_valid_role(["admin-full"])
-    )
+    return render_template_custom("admin/index.html", can_create_users=user_has_a_valid_role(["admin-full"]))
 
 
 def admin_confirm_user(app):
@@ -157,13 +151,8 @@ def admin_confirm_user(app):
     session["admin_user_email"] = admin_user_object["email"]
     session["admin_user_object"] = admin_user_object
 
-    return render_template_custom(
-        app,
-        "admin/confirm-user.html",
-        user=admin_user_object,
-        new_user=new_user,
-        user_group=admin_user_object["group"],
-    )
+    return render_template_custom("admin/confirm-user.html", user=admin_user_object, new_user=new_user,
+                                  user_group=admin_user_object["group"])
 
 
 def parse_edit_form_fields(post_fields: dict, admin_user_object: dict, app: Flask):
@@ -297,19 +286,12 @@ def admin_edit_user(app):
         admin_user_object = remove_invalid_user_paths(admin_user_object)
         user_custom_paths = admin_user_object["custom:paths"].split(";")
 
-    return render_template_custom(
-        app,
-        "admin/edit-user.html",
-        user=admin_user_object,
-        new_user=new_user,
-        user_custom_paths=user_custom_paths,
-        local_authority=value_paths_by_type("local_authority"),
-        is_la=is_local_authority_user,
-        other=value_paths_by_type("other"),
-        is_other=is_other_user,
-        allowed_domains=(User(admin_user_email).allowed_domains() if new_user else []),
-        available_groups=user_groups(),
-    )
+    return render_template_custom("admin/edit-user.html", user=admin_user_object, new_user=new_user,
+                                  user_custom_paths=user_custom_paths,
+                                  local_authority=value_paths_by_type("local_authority"), is_la=is_local_authority_user,
+                                  other=value_paths_by_type("other"), is_other=is_other_user,
+                                  allowed_domains=(User(admin_user_email).allowed_domains() if new_user else []),
+                                  available_groups=user_groups())
 
 
 def admin_reinvite_user(app):
@@ -328,12 +310,8 @@ def admin_reinvite_user(app):
         session["admin_user_email"] = email
         return redirect("/admin/user?done=reinvited")
 
-    return render_template_custom(
-        app,
-        "admin/confirm-reinvite.html",
-        email=quote(admin_user_object["email"]),
-        user_email=admin_user_object["email"],
-    )
+    return render_template_custom("admin/confirm-reinvite.html", email=quote(admin_user_object["email"]),
+                                  user_email=admin_user_object["email"])
 
 
 def admin_enable_user(app):
@@ -353,12 +331,8 @@ def admin_enable_user(app):
         session["admin_user_email"] = email
         return redirect("/admin/user?done=enabled")
 
-    return render_template_custom(
-        app,
-        "admin/confirm-enable.html",
-        email=quote(admin_user_object["email"]),
-        user_email=admin_user_object["email"],
-    )
+    return render_template_custom("admin/confirm-enable.html", email=quote(admin_user_object["email"]),
+                                  user_email=admin_user_object["email"])
 
 
 def admin_disable_user(app):
@@ -378,12 +352,8 @@ def admin_disable_user(app):
         session["admin_user_email"] = email
         return redirect("/admin/user?done=disabled")
 
-    return render_template_custom(
-        app,
-        "admin/confirm-disable.html",
-        email=quote(admin_user_object["email"]),
-        user_email=admin_user_object["email"],
-    )
+    return render_template_custom("admin/confirm-disable.html", email=quote(admin_user_object["email"]),
+                                  user_email=admin_user_object["email"])
 
 
 def admin_delete_user(app):
@@ -402,13 +372,9 @@ def admin_delete_user(app):
         User(email).delete()
         return redirect("/admin?done=deleted")
 
-    return render_template_custom(
-        app,
-        "admin/confirm-delete.html",
-        email=quote(admin_user_object["email"]),
-        user_email=admin_user_object["email"],
-    )
+    return render_template_custom("admin/confirm-delete.html", email=quote(admin_user_object["email"]),
+                                  user_email=admin_user_object["email"])
 
 
 def admin_user_not_found(app):
-    return render_template_custom(app, "error.html", error="User not found")
+    return render_template_custom("error.html", error="User not found")

--- a/admin.py
+++ b/admin.py
@@ -58,7 +58,9 @@ def admin_user(app):
 
             user_group = return_users_group(user)
 
-            return render_template_custom("admin/user.html", user=user, user_group=user_group, done=done)
+            return render_template_custom(
+                "admin/user.html", user=user, user_group=user_group, done=done
+            )
 
     return redirect("/admin/user/not-found")
 
@@ -96,7 +98,9 @@ def admin_list_users(app):
 
 def admin_main(app):
     clear_session(app)
-    return render_template_custom("admin/index.html", can_create_users=user_has_a_valid_role(["admin-full"]))
+    return render_template_custom(
+        "admin/index.html", can_create_users=user_has_a_valid_role(["admin-full"])
+    )
 
 
 def admin_confirm_user(app):
@@ -151,8 +155,12 @@ def admin_confirm_user(app):
     session["admin_user_email"] = admin_user_object["email"]
     session["admin_user_object"] = admin_user_object
 
-    return render_template_custom("admin/confirm-user.html", user=admin_user_object, new_user=new_user,
-                                  user_group=admin_user_object["group"])
+    return render_template_custom(
+        "admin/confirm-user.html",
+        user=admin_user_object,
+        new_user=new_user,
+        user_group=admin_user_object["group"],
+    )
 
 
 def parse_edit_form_fields(post_fields: dict, admin_user_object: dict, app: Flask):
@@ -286,12 +294,18 @@ def admin_edit_user(app):
         admin_user_object = remove_invalid_user_paths(admin_user_object)
         user_custom_paths = admin_user_object["custom:paths"].split(";")
 
-    return render_template_custom("admin/edit-user.html", user=admin_user_object, new_user=new_user,
-                                  user_custom_paths=user_custom_paths,
-                                  local_authority=value_paths_by_type("local_authority"), is_la=is_local_authority_user,
-                                  other=value_paths_by_type("other"), is_other=is_other_user,
-                                  allowed_domains=(User(admin_user_email).allowed_domains() if new_user else []),
-                                  available_groups=user_groups())
+    return render_template_custom(
+        "admin/edit-user.html",
+        user=admin_user_object,
+        new_user=new_user,
+        user_custom_paths=user_custom_paths,
+        local_authority=value_paths_by_type("local_authority"),
+        is_la=is_local_authority_user,
+        other=value_paths_by_type("other"),
+        is_other=is_other_user,
+        allowed_domains=(User(admin_user_email).allowed_domains() if new_user else []),
+        available_groups=user_groups(),
+    )
 
 
 def admin_reinvite_user(app):
@@ -310,8 +324,11 @@ def admin_reinvite_user(app):
         session["admin_user_email"] = email
         return redirect("/admin/user?done=reinvited")
 
-    return render_template_custom("admin/confirm-reinvite.html", email=quote(admin_user_object["email"]),
-                                  user_email=admin_user_object["email"])
+    return render_template_custom(
+        "admin/confirm-reinvite.html",
+        email=quote(admin_user_object["email"]),
+        user_email=admin_user_object["email"],
+    )
 
 
 def admin_enable_user(app):
@@ -331,8 +348,11 @@ def admin_enable_user(app):
         session["admin_user_email"] = email
         return redirect("/admin/user?done=enabled")
 
-    return render_template_custom("admin/confirm-enable.html", email=quote(admin_user_object["email"]),
-                                  user_email=admin_user_object["email"])
+    return render_template_custom(
+        "admin/confirm-enable.html",
+        email=quote(admin_user_object["email"]),
+        user_email=admin_user_object["email"],
+    )
 
 
 def admin_disable_user(app):
@@ -352,8 +372,11 @@ def admin_disable_user(app):
         session["admin_user_email"] = email
         return redirect("/admin/user?done=disabled")
 
-    return render_template_custom("admin/confirm-disable.html", email=quote(admin_user_object["email"]),
-                                  user_email=admin_user_object["email"])
+    return render_template_custom(
+        "admin/confirm-disable.html",
+        email=quote(admin_user_object["email"]),
+        user_email=admin_user_object["email"],
+    )
 
 
 def admin_delete_user(app):
@@ -372,8 +395,11 @@ def admin_delete_user(app):
         User(email).delete()
         return redirect("/admin?done=deleted")
 
-    return render_template_custom("admin/confirm-delete.html", email=quote(admin_user_object["email"]),
-                                  user_email=admin_user_object["email"])
+    return render_template_custom(
+        "admin/confirm-delete.html",
+        email=quote(admin_user_object["email"]),
+        user_email=admin_user_object["email"],
+    )
 
 
 def admin_user_not_found(app):

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -141,7 +141,7 @@ def upload_rights_required(flask_route):
     return decorated_function
 
 
-def render_template_custom(app, template, hide_logout=False, **args):
+def render_template_custom(template, hide_logout=False, **args):
     args["is_admin_interface"] = is_admin_interface()
     show_back_link = template not in ["welcome.html", "login.html"]
 

--- a/main.py
+++ b/main.py
@@ -221,8 +221,13 @@ def index():
     if "details" in session:
         upload_rights = has_upload_rights()
         is_admin_role = has_admin_role()
-        return render_template_custom("welcome.html", user=session["user"], email=session["email"],
-                                      upload_rights=upload_rights, is_admin_role=is_admin_role)
+        return render_template_custom(
+            "welcome.html",
+            user=session["user"],
+            email=session["email"],
+            upload_rights=upload_rights,
+            is_admin_role=is_admin_role,
+        )
     else:
         login_url = (
             f"https://{app.config['cognito_domain']}/oauth2/authorize?"
@@ -231,7 +236,9 @@ def index():
             f"redirect_uri={app.config['redirect_host']}&"
             "scope=profile+email+phone+openid+aws.cognito.signin.user.admin"
         )
-        return render_template_custom("login.html", hide_logout=True, login_url=login_url)
+        return render_template_custom(
+            "login.html", hide_logout=True, login_url=login_url
+        )
 
 
 @app.route("/logout")
@@ -334,12 +341,18 @@ def upload():
         upload_history = get_upload_history(config.get("bucket_name"), session)
         app.logger.debug({"uploads": upload_history})
 
-    return render_template_custom("upload.html", user=session["user"], email=session["email"],
-                                  is_la=return_attribute(session, "custom:is_la"), presigned_object=presigned_object,
-                                  preupload=preupload, filepathtoupload=file_path_to_upload,
-                                  file_extensions=list(file_extensions.values()) if preupload else {},
-                                  upload_keys=user_upload_paths if preupload else [],
-                                  upload_history=collect_files_by_date(upload_history))
+    return render_template_custom(
+        "upload.html",
+        user=session["user"],
+        email=session["email"],
+        is_la=return_attribute(session, "custom:is_la"),
+        presigned_object=presigned_object,
+        preupload=preupload,
+        filepathtoupload=file_path_to_upload,
+        file_extensions=list(file_extensions.values()) if preupload else {},
+        upload_keys=user_upload_paths if preupload else [],
+        upload_history=collect_files_by_date(upload_history),
+    )
 
 
 def generate_upload_file_path(form_fields):
@@ -439,8 +452,13 @@ def files():
 
     # TODO sorting
 
-    return render_template_custom("files.html", user=session["user"], email=session["email"],
-                                  files=collect_files_by_date(files), is_la=return_attribute(session, "custom:is_la"))
+    return render_template_custom(
+        "files.html",
+        user=session["user"],
+        email=session["email"],
+        files=collect_files_by_date(files),
+        is_la=return_attribute(session, "custom:is_la"),
+    )
 
 
 # ----------- ADMIN ROUTES -----------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,7 +48,10 @@ def test_load_ssm_parameters(test_ssm_parameters):
         )
         assert config.get("cognito_pool_id") == test_ssm_parameters["/cognito/pool/id"]
         assert config.get("bucket_name") == test_ssm_parameters["/s3/bucket_name"]
-        assert config.get("bucket_main_prefix") == test_ssm_parameters["/s3/bucket_main_prefix"]
+        assert (
+            config.get("bucket_main_prefix")
+            == test_ssm_parameters["/s3/bucket_main_prefix"]
+        )
         stubber.deactivate()
 
 


### PR DESCRIPTION
Redirects to 500 error page if a jinja2.TemplateError is raised. 

This is a guess of what might be causing the intermittent errors
in the e2e tests.

Remove unused app argument from the template render function
Add a custom errorhandler for jinja2.TemplateError