### PR TITLE
Remove workaround to delegate auth to AWS credentials offline.

### DIFF
--- a/cognito.py
+++ b/cognito.py
@@ -11,7 +11,7 @@ perform on behalf of other users.
 import boto3
 from botocore.exceptions import ClientError, ParamValidationError
 
-from cognito_groups import get_group_by_name, get_group_map
+from cognito_groups import get_group_map
 from logger import LOG
 import config
 

--- a/cognito.py
+++ b/cognito.py
@@ -8,9 +8,6 @@ API operations prefixed with admin_ are operations administrators
 perform on behalf of other users.
 """
 
-import os
-import re
-
 import boto3
 from botocore.exceptions import ClientError, ParamValidationError
 

--- a/main.py
+++ b/main.py
@@ -13,7 +13,6 @@ from requests.auth import HTTPBasicAuth
 from werkzeug.utils import secure_filename
 
 import admin
-import cognito
 import config
 from flask_helpers import (
     admin_interface,

--- a/main.py
+++ b/main.py
@@ -205,10 +205,6 @@ def index():
 
     args = request.args
 
-    # TODO remove below if statement once admin app running online
-    if "details" not in session and cognito.is_aws_authenticated():
-        cognito.delegate_auth_to_aws(session)
-
     if "code" in args:
         oauth_code = args["code"]
         response = exchange_code_for_session_user(oauth_code)


### PR DESCRIPTION
Previously we ran the admin console locally to manage cognito users.
This workaround enabled us to mock a session without going via
cognito because we didn't want the cognito client to accept redirects
from localhost.

Now the user admin is managed through the lambda this is no longer