### PR TITLE
Remove reload button from files page.

### DIFF
--- a/templates/files.html
+++ b/templates/files.html
@@ -1,12 +1,6 @@
 {% extends 'primary.html' %}
 {% block content %}
 
-  <p>
-    <a href="/files" role="button" draggable="false" class="govuk-button covid-transfer-reload-button" data-module="govuk-button">
-      Reload
-    </a>
-  </p>
-
   {% include 'components/support.html' %}
 
   <p>


### PR DESCRIPTION
No longer needed due to moving creation of presigned urls.

Previously the presigned URLS were created in the /files route with an expiry on 20 minutes so if you stayed on the page longer they stopped working and you had to reload to regenerate them with a new expiry. 

Now the links on the /files page are to the /download route which generates the presigned URL when you click a link and redirects you straight to it. 