### PR TITLE
Stop getting the username for each file that could be downloaded

### DIFF
--- a/main.py
+++ b/main.py
@@ -584,6 +584,7 @@ def create_presigned_url(bucket_name: str, object_name: str, expiration=3600) ->
 def get_files(bucket_name: str, user_session: dict):
     prefixes = load_user_lookup(user_session)
     app.logger.debug({"prefixes": prefixes})
+    username = user_session["user"]
 
     file_keys = list_s3_bucket_matching_prefixes(bucket_name, prefixes)
 
@@ -591,7 +592,7 @@ def get_files(bucket_name: str, user_session: dict):
 
     for file_key in file_keys:
         app.logger.info(
-            "User {}: file_key: {}".format(user_session["user"], file_key["key"])
+            "User {}: file_key: {}".format(username, file_key["key"])
         )
 
         url_string = f"/download/{file_key['key']}"


### PR DESCRIPTION
Users have seen 502s (from the ALB) when generating the `/files` page
when there are large numbers of files that could be downloaded. This is
reproduceable when a user has access to two or more LAs.

In the Cloudwatch logs it is observable that the `INFO` log lines
produced by line 594-596 of `main.py` span a period of 5 seconds.

I initially considered that this might be due to slow S3 API calls, but
by the point the lines are logged all the API calls have been made.

I also thought that writing to `stdout` might be slow for some reason, I
increased the log level to `WARN` and the timeout still happened.

At this point I'm taking a punt on accessing keys on `user_session` is
slow. It's not a plain Python `dict` and does some tracking of access,
changes, validation of signatures. I'm guessing that it may be slow-ish.

We don't have any real instrumentation for stuff happening inside the
app so I'm taking a bit of a guess at this fixing the problem.