### PR TITLE
Revert "Update flask requirement from ==1.1.* to ==2.0.*"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask == 2.0.*
+Flask == 1.1.*
 boto3 == 1.12.*
 requests == 2.23.*
 flask-talisman == 0.7.0


### PR DESCRIPTION
Reverts alphagov/transfer-coronavirus-data-service#120

This is because lambda runs on python 2.X and flask removes compatibility