### PR TITLE
Use google chrome stable

### DIFF
--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -14,8 +14,8 @@ def before_scenario(context, _scenario):
     # context.browser.set_window_size(1080,800)
 
     options = Options()
-    options.binary = "bin/headless-chromium"
-    options.add_argument("-headless")
+    options.binary = "/usr/bin/google-chrome-stable"
+    options.add_argument("--headless")
     options.add_argument("--no-sandbox")
     options.add_argument("--single-process")
     options.add_argument("--disable-dev-shm-usage")


### PR DESCRIPTION
https://github.com/alphagov/covid-engineering/commit/7a68739f7fedeebad57ccad1ef6400d218e68720
removed headless-chromium. This PR tries to use google-chrome-stable in
headless mode instead.