### PR TITLE
Fix exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -164,7 +164,7 @@ def send_browser_config():
 def server_error_403():
     error_message = session.get("error_message", "Access denied")
     app.logger.error(f"Server error: {error_message}")
-    del session["error_message"]
+    session.pop("error_message", None)
     return (
         render_template_custom("error.html", hide_logout=True, error=error_message),
         403,


### PR DESCRIPTION
We're seeing Sentry errors with KeyError: `error_message` on this
line.

This is presumably because we're trying to delete a key that doesn't
exist.

This commit uses dict.pop(key, default) to delete a key from a
dictionary only if it exists.  This should stop the exceptions from
happening.